### PR TITLE
Issue #13: align provider name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Milestone 0: bootstrap, CI, skeleton provider, and XML client scaffolding with m
 ## Provider configuration
 
 ```hcl
-provider "hpe_msa" {
+provider "hpe" {
   endpoint     = "https://msa.example.com"
   username     = "msa_user"
   password     = "example-password"

--- a/examples/provider.tf
+++ b/examples/provider.tf
@@ -7,7 +7,7 @@ terraform {
   }
 }
 
-provider "hpe_msa" {
+provider "hpe" {
   endpoint     = "https://msa.example.com"
   username     = "msa_user"
   password     = "example-password"

--- a/internal/provider/datasource_host.go
+++ b/internal/provider/datasource_host.go
@@ -27,7 +27,7 @@ type hostDataSourceModel struct {
 }
 
 func (d *hostDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_host"
+	resp.TypeName = req.ProviderTypeName + "_msa_host"
 }
 
 func (d *hostDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/provider/datasource_pool.go
+++ b/internal/provider/datasource_pool.go
@@ -26,7 +26,7 @@ type poolDataSourceModel struct {
 }
 
 func (d *poolDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_pool"
+	resp.TypeName = req.ProviderTypeName + "_msa_pool"
 }
 
 func (d *poolDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -46,7 +46,7 @@ type resolvedConfig struct {
 }
 
 func (p *msaProvider) Metadata(_ context.Context, _ provider.MetadataRequest, resp *provider.MetadataResponse) {
-	resp.TypeName = "hpe_msa"
+	resp.TypeName = "hpe"
 	resp.Version = p.version
 }
 

--- a/internal/provider/resource_volume.go
+++ b/internal/provider/resource_volume.go
@@ -40,7 +40,7 @@ type volumeResourceModel struct {
 }
 
 func (r *volumeResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
-	resp.TypeName = req.ProviderTypeName + "_volume"
+	resp.TypeName = req.ProviderTypeName + "_msa_volume"
 }
 
 func (r *volumeResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {


### PR DESCRIPTION
Fixes #13.\n\n- Set provider type name to a Terraform-valid identifier.\n- Preserve hpe_msa_* resource and data source prefixes.\n- Update docs/examples to use provider "hpe".\n\nTests: go test ./...