### PR TITLE
Add host and initiator resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Production-quality Terraform provider for HPE MSA 2050 arrays (firmware VL270P00
 
 ## Status
 
-Milestone 0: bootstrap, CI, skeleton provider, and XML client scaffolding with mocks. Resources and data sources will be implemented in subsequent milestones.
+Implemented resources: volumes, snapshots, initiators, hosts, and host initiator membership. Pending: clones, mappings, acceptance tests, and hardening.
 
 ## Requirements
 
@@ -80,6 +80,55 @@ Import by serial number:
 
 ```bash
 terraform import hpe_msa_snapshot.example SERIAL-NUMBER
+```
+
+### Initiator + Host
+
+```hcl
+resource "hpe_msa_initiator" "init1" {
+  initiator_id = "20000000000000c1"
+  nickname     = "tf-init-01"
+  allow_destroy = false
+}
+
+resource "hpe_msa_host" "host1" {
+  name        = "tf-host-01"
+  initiators  = [hpe_msa_initiator.init1.initiator_id]
+  allow_destroy = false
+}
+```
+
+Import by initiator ID:
+
+```bash
+terraform import hpe_msa_initiator.init1 20000000000000c1
+```
+
+Import by host name:
+
+```bash
+terraform import hpe_msa_host.host1 tf-host-01
+```
+
+### Host membership
+
+```hcl
+resource "hpe_msa_initiator" "init2" {
+  initiator_id = "20000000000000c2"
+  nickname     = "tf-init-02"
+  allow_destroy = false
+}
+
+resource "hpe_msa_host_initiator" "member" {
+  host_name    = hpe_msa_host.host1.name
+  initiator_id = hpe_msa_initiator.init2.initiator_id
+}
+```
+
+Import by host and initiator ID:
+
+```bash
+terraform import hpe_msa_host_initiator.member tf-host-01:20000000000000c2
 ```
 
 ## Data sources

--- a/examples/host.tf
+++ b/examples/host.tf
@@ -1,0 +1,5 @@
+resource "hpe_msa_host" "example" {
+  name        = "tf-host-01"
+  initiators  = [hpe_msa_initiator.example.initiator_id]
+  allow_destroy = false
+}

--- a/examples/host_initiator.tf
+++ b/examples/host_initiator.tf
@@ -1,0 +1,10 @@
+resource "hpe_msa_initiator" "extra" {
+  initiator_id = "20000000000000c2"
+  nickname     = "tf-init-02"
+  allow_destroy = false
+}
+
+resource "hpe_msa_host_initiator" "example" {
+  host_name    = hpe_msa_host.example.name
+  initiator_id = hpe_msa_initiator.extra.initiator_id
+}

--- a/examples/initiator.tf
+++ b/examples/initiator.tf
@@ -1,0 +1,5 @@
+resource "hpe_msa_initiator" "example" {
+  initiator_id = "20000000000000c1"
+  nickname     = "tf-init-01"
+  allow_destroy = false
+}

--- a/internal/msa/host.go
+++ b/internal/msa/host.go
@@ -1,0 +1,51 @@
+package msa
+
+import (
+	"strconv"
+	"strings"
+)
+
+type Host struct {
+	Name         string
+	DurableID    string
+	SerialNumber string
+	HostGroup    string
+	GroupKey     string
+	MemberCount  int
+	Properties   map[string]string
+}
+
+func HostsFromResponse(response Response) []Host {
+	hosts := make([]Host, 0)
+	for _, obj := range response.ObjectsWithoutStatus() {
+		if !isHostObject(obj) {
+			continue
+		}
+		hosts = append(hosts, hostFromObject(obj))
+	}
+	return hosts
+}
+
+func isHostObject(obj Object) bool {
+	return obj.BaseType == "host"
+}
+
+func hostFromObject(obj Object) Host {
+	props := obj.PropertyMap()
+	memberCount := 0
+	if value := strings.TrimSpace(props["member-count"]); value != "" {
+		if parsed, err := strconv.Atoi(value); err == nil {
+			memberCount = parsed
+		}
+	}
+
+	return Host{
+		Name:         firstNonEmpty(props["name"], obj.Name),
+		DurableID:    props["durable-id"],
+		SerialNumber: props["serial-number"],
+		HostGroup:    props["host-group"],
+		GroupKey:     props["group-key"],
+		MemberCount:  memberCount,
+		Properties:   props,
+	}
+}

--- a/internal/msa/host_test.go
+++ b/internal/msa/host_test.go
@@ -1,0 +1,32 @@
+package msa
+
+import "testing"
+
+func TestHostsFromResponse(t *testing.T) {
+	fixture := readFixture(t, "show_host_groups.xml")
+	response, err := parseResponse(fixture)
+	if err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+
+	hosts := HostsFromResponse(response)
+	if len(hosts) != 2 {
+		t.Fatalf("expected 2 hosts, got %d", len(hosts))
+	}
+
+	if hosts[0].Name != "HostA" {
+		t.Fatalf("expected HostA, got %q", hosts[0].Name)
+	}
+	if hosts[0].DurableID != "H1" {
+		t.Fatalf("expected durable id H1, got %q", hosts[0].DurableID)
+	}
+	if hosts[0].SerialNumber != "00c0ff3cab9c00000000000001010000" {
+		t.Fatalf("unexpected serial number %q", hosts[0].SerialNumber)
+	}
+	if hosts[0].MemberCount != 2 {
+		t.Fatalf("expected member count 2, got %d", hosts[0].MemberCount)
+	}
+	if hosts[0].HostGroup != "UNGROUPEDHOSTS" {
+		t.Fatalf("expected host group UNGROUPEDHOSTS, got %q", hosts[0].HostGroup)
+	}
+}

--- a/internal/msa/initiator.go
+++ b/internal/msa/initiator.go
@@ -1,0 +1,50 @@
+package msa
+
+import "strings"
+
+type Initiator struct {
+	ID          string
+	Nickname    string
+	Profile     string
+	HostID      string
+	HostKey     string
+	HostBusType string
+	Discovered  string
+	Mapped      string
+	Properties  map[string]string
+}
+
+func InitiatorsFromResponse(response Response) []Initiator {
+	initiators := make([]Initiator, 0)
+	for _, obj := range response.ObjectsWithoutStatus() {
+		if !isInitiatorObject(obj) {
+			continue
+		}
+		initiators = append(initiators, initiatorFromObject(obj))
+	}
+	return initiators
+}
+
+func isInitiatorObject(obj Object) bool {
+	if obj.BaseType == "initiator" {
+		return true
+	}
+	_, ok := obj.PropertyValue("id")
+	return ok
+}
+
+func initiatorFromObject(obj Object) Initiator {
+	props := obj.PropertyMap()
+
+	return Initiator{
+		ID:          strings.TrimSpace(props["id"]),
+		Nickname:    strings.TrimSpace(props["nickname"]),
+		Profile:     strings.TrimSpace(props["profile"]),
+		HostID:      strings.TrimSpace(props["host-id"]),
+		HostKey:     strings.TrimSpace(props["host-key"]),
+		HostBusType: strings.TrimSpace(props["host-bus-type"]),
+		Discovered:  strings.TrimSpace(props["discovered"]),
+		Mapped:      strings.TrimSpace(props["mapped"]),
+		Properties:  props,
+	}
+}

--- a/internal/msa/initiator_test.go
+++ b/internal/msa/initiator_test.go
@@ -1,0 +1,29 @@
+package msa
+
+import "testing"
+
+func TestInitiatorsFromResponse(t *testing.T) {
+	fixture := readFixture(t, "show_initiators.xml")
+	response, err := parseResponse(fixture)
+	if err != nil {
+		t.Fatalf("parse response: %v", err)
+	}
+
+	initiators := InitiatorsFromResponse(response)
+	if len(initiators) != 2 {
+		t.Fatalf("expected 2 initiators, got %d", len(initiators))
+	}
+
+	if initiators[0].ID != "20000000000000c1" {
+		t.Fatalf("unexpected initiator id %q", initiators[0].ID)
+	}
+	if initiators[0].Nickname != "InitA" {
+		t.Fatalf("unexpected nickname %q", initiators[0].Nickname)
+	}
+	if initiators[0].HostKey != "H1" {
+		t.Fatalf("unexpected host key %q", initiators[0].HostKey)
+	}
+	if initiators[0].Profile != "Standard" {
+		t.Fatalf("unexpected profile %q", initiators[0].Profile)
+	}
+}

--- a/internal/msa/object.go
+++ b/internal/msa/object.go
@@ -10,9 +10,27 @@ func (o Object) PropertyMap() map[string]string {
 	return props
 }
 
-func (r Response) ObjectsWithoutStatus() []Object {
+func (o Object) AllObjects() []Object {
+	objects := make([]Object, 0, len(o.Objects))
+	for _, obj := range o.Objects {
+		objects = append(objects, obj)
+		objects = append(objects, obj.AllObjects()...)
+	}
+	return objects
+}
+
+func (r Response) AllObjects() []Object {
 	objects := make([]Object, 0, len(r.Objects))
 	for _, obj := range r.Objects {
+		objects = append(objects, obj)
+		objects = append(objects, obj.AllObjects()...)
+	}
+	return objects
+}
+
+func (r Response) ObjectsWithoutStatus() []Object {
+	objects := make([]Object, 0, len(r.Objects))
+	for _, obj := range r.AllObjects() {
 		if obj.BaseType == "status" || obj.Name == "status" {
 			continue
 		}

--- a/internal/msa/testdata/show_host_groups.xml
+++ b/internal/msa/testdata/show_host_groups.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RESPONSE VERSION="L100" REQUEST="show host-groups">
+  <OBJECT basetype="host-group" name="host-group" oid="1" format="rows">
+    <PROPERTY name="durable-id" type="string">HG0</PROPERTY>
+    <PROPERTY name="name" type="string">UNGROUPED</PROPERTY>
+    <PROPERTY name="serial-number" type="string">UNGROUPEDHOSTS</PROPERTY>
+    <PROPERTY name="member-count" type="uint32">2</PROPERTY>
+    <OBJECT basetype="host" name="host" oid="2" format="rows">
+      <PROPERTY name="durable-id" type="string">H1</PROPERTY>
+      <PROPERTY name="name" type="string">HostA</PROPERTY>
+      <PROPERTY name="serial-number" type="string">00c0ff3cab9c00000000000001010000</PROPERTY>
+      <PROPERTY name="member-count" type="uint32">2</PROPERTY>
+      <PROPERTY name="host-group" type="string">UNGROUPEDHOSTS</PROPERTY>
+      <PROPERTY name="group-key" type="string">HG0</PROPERTY>
+    </OBJECT>
+    <OBJECT basetype="host" name="host" oid="3" format="rows">
+      <PROPERTY name="durable-id" type="string">H2</PROPERTY>
+      <PROPERTY name="name" type="string">HostB</PROPERTY>
+      <PROPERTY name="serial-number" type="string">00c0ff3cab9c00000000000002010000</PROPERTY>
+      <PROPERTY name="member-count" type="uint32">1</PROPERTY>
+      <PROPERTY name="host-group" type="string">UNGROUPEDHOSTS</PROPERTY>
+      <PROPERTY name="group-key" type="string">HG0</PROPERTY>
+    </OBJECT>
+  </OBJECT>
+  <OBJECT basetype="status" name="status" oid="99">
+    <PROPERTY name="response-type" type="string">Success</PROPERTY>
+    <PROPERTY name="response-type-numeric" type="uint32">0</PROPERTY>
+    <PROPERTY name="response" type="string">Command completed successfully.</PROPERTY>
+    <PROPERTY name="return-code" type="sint32">0</PROPERTY>
+  </OBJECT>
+</RESPONSE>

--- a/internal/msa/testdata/show_initiators.xml
+++ b/internal/msa/testdata/show_initiators.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<RESPONSE VERSION="L100" REQUEST="show initiators">
+  <OBJECT basetype="initiator" name="initiator" oid="1" format="rows">
+    <PROPERTY name="durable-id" type="string">I1</PROPERTY>
+    <PROPERTY name="nickname" type="string">InitA</PROPERTY>
+    <PROPERTY name="discovered" type="string">No</PROPERTY>
+    <PROPERTY name="mapped" type="string">No</PROPERTY>
+    <PROPERTY name="profile" type="string">Standard</PROPERTY>
+    <PROPERTY name="host-bus-type" type="string">SAS</PROPERTY>
+    <PROPERTY name="id" type="string">20000000000000c1</PROPERTY>
+    <PROPERTY name="host-id" type="string">00c0ff3cab9c00000000000001010000</PROPERTY>
+    <PROPERTY name="host-key" type="string">H1</PROPERTY>
+  </OBJECT>
+  <OBJECT basetype="initiator" name="initiator" oid="2" format="rows">
+    <PROPERTY name="durable-id" type="string">I2</PROPERTY>
+    <PROPERTY name="nickname" type="string">InitB</PROPERTY>
+    <PROPERTY name="discovered" type="string">Yes</PROPERTY>
+    <PROPERTY name="mapped" type="string">Yes</PROPERTY>
+    <PROPERTY name="profile" type="string">HP-UX</PROPERTY>
+    <PROPERTY name="host-bus-type" type="string">SAS</PROPERTY>
+    <PROPERTY name="id" type="string">20000000000000c2</PROPERTY>
+    <PROPERTY name="host-id" type="string">00c0ff3cab9c00000000000002010000</PROPERTY>
+    <PROPERTY name="host-key" type="string">H2</PROPERTY>
+  </OBJECT>
+  <OBJECT basetype="status" name="status" oid="99">
+    <PROPERTY name="response-type" type="string">Success</PROPERTY>
+    <PROPERTY name="response-type-numeric" type="uint32">0</PROPERTY>
+    <PROPERTY name="response" type="string">Command completed successfully.</PROPERTY>
+    <PROPERTY name="return-code" type="sint32">0</PROPERTY>
+  </OBJECT>
+</RESPONSE>

--- a/internal/msa/xml.go
+++ b/internal/msa/xml.go
@@ -17,6 +17,7 @@ type Object struct {
 	Name       string     `xml:"name,attr"`
 	OID        string     `xml:"oid,attr"`
 	Properties []Property `xml:"PROPERTY"`
+	Objects    []Object   `xml:"OBJECT"`
 }
 
 type Property struct {
@@ -45,7 +46,7 @@ func (o Object) PropertyValue(name string) (string, bool) {
 }
 
 func (r Response) Status() (Status, bool) {
-	for _, obj := range r.Objects {
+	for _, obj := range r.AllObjects() {
 		if obj.BaseType == "status" || obj.Name == "status" {
 			status := Status{}
 			if value, ok := obj.PropertyValue("response-type"); ok {

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -115,6 +115,9 @@ func (p *msaProvider) Resources(_ context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
 		NewVolumeResource,
 		NewSnapshotResource,
+		NewInitiatorResource,
+		NewHostResource,
+		NewHostInitiatorResource,
 	}
 }
 

--- a/internal/provider/resource_host.go
+++ b/internal/provider/resource_host.go
@@ -1,0 +1,406 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/d3vi1/tf-provider-hpe-msa/internal/msa"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = (*hostResource)(nil)
+var _ resource.ResourceWithImportState = (*hostResource)(nil)
+
+func NewHostResource() resource.Resource {
+	return &hostResource{}
+}
+
+type hostResource struct {
+	client *msa.Client
+}
+
+type hostResourceModel struct {
+	ID           types.String `tfsdk:"id"`
+	Name         types.String `tfsdk:"name"`
+	Initiators   types.Set    `tfsdk:"initiators"`
+	HostGroup    types.String `tfsdk:"host_group"`
+	Profile      types.String `tfsdk:"profile"`
+	DurableID    types.String `tfsdk:"durable_id"`
+	SerialNumber types.String `tfsdk:"serial_number"`
+	GroupKey     types.String `tfsdk:"group_key"`
+	MemberCount  types.Int64  `tfsdk:"member_count"`
+	Properties   types.Map    `tfsdk:"properties"`
+	AllowDestroy types.Bool   `tfsdk:"allow_destroy"`
+}
+
+func (r *hostResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_msa_host"
+}
+
+func (r *hostResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Host identifier (serial number).",
+				Computed:    true,
+			},
+			"name": schema.StringAttribute{
+				Description: "Host name.",
+				Required:    true,
+			},
+			"initiators": schema.SetAttribute{
+				Description: "Initiator IDs or nicknames to seed the host (comma-free values).",
+				Required:    true,
+				ElementType: types.StringType,
+				PlanModifiers: []planmodifier.Set{
+					setplanmodifier.RequiresReplace(),
+				},
+			},
+			"host_group": schema.StringAttribute{
+				Description: "Optional host group name to add the host to.",
+				Optional:    true,
+				Computed:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"profile": schema.StringAttribute{
+				Description: "Host profile (standard, hp-ux, openvms).",
+				Optional:    true,
+				Computed:    true,
+			},
+			"durable_id": schema.StringAttribute{
+				Description: "Durable ID reported by the array.",
+				Computed:    true,
+			},
+			"serial_number": schema.StringAttribute{
+				Description: "Host serial number reported by the array.",
+				Computed:    true,
+			},
+			"group_key": schema.StringAttribute{
+				Description: "Host group key reported by the array.",
+				Computed:    true,
+			},
+			"member_count": schema.Int64Attribute{
+				Description: "Number of initiators in the host.",
+				Computed:    true,
+			},
+			"properties": schema.MapAttribute{
+				Description: "Raw properties returned by the XML API.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"allow_destroy": schema.BoolAttribute{
+				Description: "Require explicit opt-in to delete hosts.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+		},
+	}
+}
+
+func (r *hostResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*msa.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *msa.Client")
+		return
+	}
+
+	r.client = client
+}
+
+func (r *hostResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan hostResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	name := strings.TrimSpace(plan.Name.ValueString())
+	if name == "" {
+		resp.Diagnostics.AddError("Invalid name", "name must be provided")
+		return
+	}
+
+	initiators, diag := setToStrings(ctx, plan.Initiators)
+	resp.Diagnostics.Append(diag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if len(initiators) == 0 {
+		resp.Diagnostics.AddError("Invalid initiators", "at least one initiator is required to create a host")
+		return
+	}
+
+	parts := []string{"create", "host"}
+	if !plan.HostGroup.IsNull() && !plan.HostGroup.IsUnknown() && plan.HostGroup.ValueString() != "" {
+		parts = append(parts, "host-group", plan.HostGroup.ValueString())
+	}
+	parts = append(parts, "initiators", strings.Join(initiators, ","))
+	if !plan.Profile.IsNull() && !plan.Profile.IsUnknown() && plan.Profile.ValueString() != "" {
+		parts = append(parts, "profile", plan.Profile.ValueString())
+	}
+	parts = append(parts, name)
+
+	_, err := r.client.Execute(ctx, parts...)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to create host", err.Error())
+		return
+	}
+
+	host, err := r.waitForHost(ctx, name)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read host after create", err.Error())
+		return
+	}
+
+	state, diag := hostStateFromModel(ctx, plan, host)
+	resp.Diagnostics.Append(diag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *hostResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state hostResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	name := strings.TrimSpace(state.Name.ValueString())
+	if name == "" {
+		resp.Diagnostics.AddError("Invalid state", "name is required")
+		return
+	}
+
+	host, err := r.findHost(ctx, name)
+	if err != nil {
+		if errors.Is(err, errHostNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Unable to read host", err.Error())
+		return
+	}
+
+	newState, diag := hostStateFromModel(ctx, state, host)
+	resp.Diagnostics.Append(diag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+func (r *hostResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan hostResourceModel
+	var state hostResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	currentName := strings.TrimSpace(state.Name.ValueString())
+	newName := strings.TrimSpace(plan.Name.ValueString())
+	if currentName == "" || newName == "" {
+		resp.Diagnostics.AddError("Invalid name", "name must be provided")
+		return
+	}
+
+	profile := ""
+	if !plan.Profile.IsNull() && !plan.Profile.IsUnknown() {
+		profile = strings.TrimSpace(plan.Profile.ValueString())
+	}
+
+	updateParts := []string{"set", "host"}
+	changed := false
+	if currentName != newName {
+		updateParts = append(updateParts, "name", newName)
+		changed = true
+	}
+	if profile != "" {
+		updateParts = append(updateParts, "profile", profile)
+		changed = true
+	}
+	updateParts = append(updateParts, currentName)
+
+	if changed {
+		if _, err := r.client.Execute(ctx, updateParts...); err != nil {
+			resp.Diagnostics.AddError("Unable to update host", err.Error())
+			return
+		}
+	}
+
+	host, err := r.findHost(ctx, newName)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read host after update", err.Error())
+		return
+	}
+
+	newState, diag := hostStateFromModel(ctx, plan, host)
+	resp.Diagnostics.Append(diag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+func (r *hostResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state hostResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	if state.AllowDestroy.IsNull() || !state.AllowDestroy.ValueBool() {
+		resp.Diagnostics.AddError(
+			"Host deletion not permitted",
+			"Set allow_destroy = true to permit host deletion.",
+		)
+		return
+	}
+
+	name := strings.TrimSpace(state.Name.ValueString())
+	if name == "" {
+		resp.Diagnostics.AddError("Invalid state", "name is required for deletion")
+		return
+	}
+
+	_, err := r.client.Execute(ctx, "delete", "hosts", name)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to delete host", err.Error())
+		return
+	}
+}
+
+func (r *hostResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("name"), req.ID)...)
+}
+
+var errHostNotFound = errors.New("host not found")
+
+func (r *hostResource) findHost(ctx context.Context, name string) (*msa.Host, error) {
+	response, err := r.client.Execute(ctx, "show", "host-groups")
+	if err != nil {
+		return nil, err
+	}
+
+	hosts := msa.HostsFromResponse(response)
+	for _, host := range hosts {
+		if strings.EqualFold(host.Name, name) {
+			return &host, nil
+		}
+	}
+
+	return nil, errHostNotFound
+}
+
+func (r *hostResource) waitForHost(ctx context.Context, name string) (*msa.Host, error) {
+	waits := []time.Duration{1 * time.Second, 2 * time.Second, 3 * time.Second}
+	for i, wait := range waits {
+		host, err := r.findHost(ctx, name)
+		if err == nil {
+			return host, nil
+		}
+		if !errors.Is(err, errHostNotFound) {
+			return nil, err
+		}
+		if i < len(waits)-1 {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(wait):
+			}
+		}
+	}
+	return nil, errHostNotFound
+}
+
+func hostStateFromModel(ctx context.Context, model hostResourceModel, host *msa.Host) (hostResourceModel, diag.Diagnostics) {
+	state := model
+	var diags diag.Diagnostics
+
+	state.Name = types.StringValue(host.Name)
+	if host.SerialNumber != "" {
+		state.SerialNumber = types.StringValue(host.SerialNumber)
+		state.ID = types.StringValue(host.SerialNumber)
+	} else if host.DurableID != "" {
+		state.ID = types.StringValue(host.DurableID)
+	}
+	if host.DurableID != "" {
+		state.DurableID = types.StringValue(host.DurableID)
+	}
+	if host.HostGroup != "" {
+		state.HostGroup = types.StringValue(host.HostGroup)
+	}
+	if host.GroupKey != "" {
+		state.GroupKey = types.StringValue(host.GroupKey)
+	}
+	state.MemberCount = types.Int64Value(int64(host.MemberCount))
+
+	propsValue, diag := types.MapValueFrom(ctx, types.StringType, host.Properties)
+	if diag.HasError() {
+		diags.Append(diag...)
+		return state, diags
+	}
+	state.Properties = propsValue
+
+	return state, diags
+}
+
+func setToStrings(ctx context.Context, value types.Set) ([]string, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	if value.IsNull() || value.IsUnknown() {
+		return nil, diags
+	}
+	var items []string
+	diags.Append(value.ElementsAs(ctx, &items, false)...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	cleaned := make([]string, 0, len(items))
+	for _, item := range items {
+		item = strings.TrimSpace(item)
+		if item == "" {
+			continue
+		}
+		cleaned = append(cleaned, item)
+	}
+	return cleaned, diags
+}

--- a/internal/provider/resource_host_initiator.go
+++ b/internal/provider/resource_host_initiator.go
@@ -1,0 +1,238 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/d3vi1/tf-provider-hpe-msa/internal/msa"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = (*hostInitiatorResource)(nil)
+var _ resource.ResourceWithImportState = (*hostInitiatorResource)(nil)
+
+func NewHostInitiatorResource() resource.Resource {
+	return &hostInitiatorResource{}
+}
+
+type hostInitiatorResource struct {
+	client *msa.Client
+}
+
+type hostInitiatorResourceModel struct {
+	ID          types.String `tfsdk:"id"`
+	HostName    types.String `tfsdk:"host_name"`
+	InitiatorID types.String `tfsdk:"initiator_id"`
+}
+
+func (r *hostInitiatorResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_msa_host_initiator"
+}
+
+func (r *hostInitiatorResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Host/initiator association identifier.",
+				Computed:    true,
+			},
+			"host_name": schema.StringAttribute{
+				Description: "Host name.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"initiator_id": schema.StringAttribute{
+				Description: "Initiator ID or nickname to attach to the host.",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+	}
+}
+
+func (r *hostInitiatorResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*msa.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *msa.Client")
+		return
+	}
+
+	r.client = client
+}
+
+func (r *hostInitiatorResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan hostInitiatorResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	hostName := strings.TrimSpace(plan.HostName.ValueString())
+	initID := strings.TrimSpace(plan.InitiatorID.ValueString())
+	if hostName == "" || initID == "" {
+		resp.Diagnostics.AddError("Invalid configuration", "host_name and initiator_id are required")
+		return
+	}
+
+	_, err := r.client.Execute(ctx, "add", "host-members", "initiators", initID, hostName)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to add host member", err.Error())
+		return
+	}
+
+	plan.ID = types.StringValue(hostInitiatorID(hostName, initID))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *hostInitiatorResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state hostInitiatorResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	hostName := strings.TrimSpace(state.HostName.ValueString())
+	initID := strings.TrimSpace(state.InitiatorID.ValueString())
+	if hostName == "" || initID == "" {
+		resp.Diagnostics.AddError("Invalid state", "host_name and initiator_id are required")
+		return
+	}
+
+	hosts, err := r.fetchHosts(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to query hosts", err.Error())
+		return
+	}
+
+	host, ok := hosts[normalizeName(hostName)]
+	if !ok {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	initiator, err := r.fetchInitiator(ctx, initID)
+	if err != nil {
+		if errors.Is(err, errInitiatorNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Unable to query initiators", err.Error())
+		return
+	}
+
+	if !initiatorMatchesHost(initiator, host) {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	state.ID = types.StringValue(hostInitiatorID(hostName, initID))
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *hostInitiatorResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.AddError("Update not supported", "Change host_name or initiator_id by recreating the resource.")
+}
+
+func (r *hostInitiatorResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state hostInitiatorResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	hostName := strings.TrimSpace(state.HostName.ValueString())
+	initID := strings.TrimSpace(state.InitiatorID.ValueString())
+	if hostName == "" || initID == "" {
+		resp.Diagnostics.AddError("Invalid state", "host_name and initiator_id are required")
+		return
+	}
+
+	_, err := r.client.Execute(ctx, "remove", "host-members", "initiators", initID, hostName)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to remove host member", err.Error())
+		return
+	}
+}
+
+func (r *hostInitiatorResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	parts := strings.SplitN(req.ID, ":", 2)
+	if len(parts) != 2 {
+		resp.Diagnostics.AddError("Invalid import ID", "Expected host_name:initiator_id")
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("host_name"), parts[0])...)
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("initiator_id"), parts[1])...)
+}
+
+func (r *hostInitiatorResource) fetchHosts(ctx context.Context) (map[string]msa.Host, error) {
+	response, err := r.client.Execute(ctx, "show", "host-groups")
+	if err != nil {
+		return nil, err
+	}
+
+	hosts := make(map[string]msa.Host)
+	for _, host := range msa.HostsFromResponse(response) {
+		if host.Name == "" {
+			continue
+		}
+		hosts[normalizeName(host.Name)] = host
+	}
+	return hosts, nil
+}
+
+func (r *hostInitiatorResource) fetchInitiator(ctx context.Context, id string) (*msa.Initiator, error) {
+	response, err := r.client.Execute(ctx, "show", "initiators")
+	if err != nil {
+		return nil, err
+	}
+
+	for _, initiator := range msa.InitiatorsFromResponse(response) {
+		if strings.EqualFold(initiator.ID, id) || strings.EqualFold(initiator.Nickname, id) {
+			return &initiator, nil
+		}
+	}
+	return nil, errInitiatorNotFound
+}
+
+func initiatorMatchesHost(initiator *msa.Initiator, host msa.Host) bool {
+	if initiator == nil {
+		return false
+	}
+	if host.DurableID != "" && strings.EqualFold(initiator.HostKey, host.DurableID) {
+		return true
+	}
+	if host.SerialNumber != "" && strings.EqualFold(initiator.HostID, host.SerialNumber) {
+		return true
+	}
+	return false
+}
+
+func hostInitiatorID(hostName, initiatorID string) string {
+	return hostName + ":" + initiatorID
+}

--- a/internal/provider/resource_host_initiator_test.go
+++ b/internal/provider/resource_host_initiator_test.go
@@ -1,0 +1,20 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/d3vi1/tf-provider-hpe-msa/internal/msa"
+)
+
+func TestInitiatorMatchesHost(t *testing.T) {
+	host := msa.Host{DurableID: "H1", SerialNumber: "SERIAL1"}
+	initiator := &msa.Initiator{HostKey: "H1", HostID: "SERIAL1"}
+	if !initiatorMatchesHost(initiator, host) {
+		t.Fatalf("expected initiator to match host")
+	}
+
+	initiator = &msa.Initiator{HostKey: "H2", HostID: "SERIAL2"}
+	if initiatorMatchesHost(initiator, host) {
+		t.Fatalf("expected initiator not to match host")
+	}
+}

--- a/internal/provider/resource_initiator.go
+++ b/internal/provider/resource_initiator.go
@@ -1,0 +1,315 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/d3vi1/tf-provider-hpe-msa/internal/msa"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+var _ resource.Resource = (*initiatorResource)(nil)
+var _ resource.ResourceWithImportState = (*initiatorResource)(nil)
+
+func NewInitiatorResource() resource.Resource {
+	return &initiatorResource{}
+}
+
+type initiatorResource struct {
+	client *msa.Client
+}
+
+type initiatorResourceModel struct {
+	ID           types.String `tfsdk:"id"`
+	InitiatorID  types.String `tfsdk:"initiator_id"`
+	Nickname     types.String `tfsdk:"nickname"`
+	Profile      types.String `tfsdk:"profile"`
+	HostID       types.String `tfsdk:"host_id"`
+	HostKey      types.String `tfsdk:"host_key"`
+	Properties   types.Map    `tfsdk:"properties"`
+	AllowDestroy types.Bool   `tfsdk:"allow_destroy"`
+}
+
+func (r *initiatorResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = req.ProviderTypeName + "_msa_initiator"
+}
+
+func (r *initiatorResource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Description: "Initiator identifier.",
+				Computed:    true,
+			},
+			"initiator_id": schema.StringAttribute{
+				Description: "Initiator ID (WWPN or IQN).",
+				Required:    true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"nickname": schema.StringAttribute{
+				Description: "Initiator nickname.",
+				Required:    true,
+			},
+			"profile": schema.StringAttribute{
+				Description: "Initiator profile (standard, hp-ux, openvms).",
+				Optional:    true,
+				Computed:    true,
+			},
+			"host_id": schema.StringAttribute{
+				Description: "Host serial number associated with this initiator.",
+				Computed:    true,
+			},
+			"host_key": schema.StringAttribute{
+				Description: "Host key associated with this initiator.",
+				Computed:    true,
+			},
+			"properties": schema.MapAttribute{
+				Description: "Raw properties returned by the XML API.",
+				Computed:    true,
+				ElementType: types.StringType,
+			},
+			"allow_destroy": schema.BoolAttribute{
+				Description: "Require explicit opt-in to delete initiator nicknames.",
+				Optional:    true,
+				Computed:    true,
+				Default:     booldefault.StaticBool(false),
+			},
+		},
+	}
+}
+
+func (r *initiatorResource) Configure(_ context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+
+	client, ok := req.ProviderData.(*msa.Client)
+	if !ok {
+		resp.Diagnostics.AddError("Unexpected provider data type", "Expected *msa.Client")
+		return
+	}
+
+	r.client = client
+}
+
+func (r *initiatorResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var plan initiatorResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	initID := strings.TrimSpace(plan.InitiatorID.ValueString())
+	nickname := strings.TrimSpace(plan.Nickname.ValueString())
+	if initID == "" || nickname == "" {
+		resp.Diagnostics.AddError("Invalid configuration", "initiator_id and nickname are required")
+		return
+	}
+
+	if err := r.setInitiator(ctx, initID, nickname, plan.Profile); err != nil {
+		resp.Diagnostics.AddError("Unable to set initiator", err.Error())
+		return
+	}
+
+	initiator, err := r.findInitiator(ctx, initID, nickname)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read initiator after create", err.Error())
+		return
+	}
+
+	state, diag := initiatorStateFromModel(ctx, plan, initiator)
+	resp.Diagnostics.Append(diag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *initiatorResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var state initiatorResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	initID := strings.TrimSpace(state.InitiatorID.ValueString())
+	nickname := strings.TrimSpace(state.Nickname.ValueString())
+	if initID == "" && nickname == "" {
+		resp.Diagnostics.AddError("Invalid state", "initiator_id is required")
+		return
+	}
+
+	initiator, err := r.findInitiator(ctx, initID, nickname)
+	if err != nil {
+		if errors.Is(err, errInitiatorNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+		resp.Diagnostics.AddError("Unable to read initiator", err.Error())
+		return
+	}
+
+	newState, diag := initiatorStateFromModel(ctx, state, initiator)
+	resp.Diagnostics.Append(diag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+func (r *initiatorResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var plan initiatorResourceModel
+	var state initiatorResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	initID := strings.TrimSpace(plan.InitiatorID.ValueString())
+	nickname := strings.TrimSpace(plan.Nickname.ValueString())
+	if initID == "" || nickname == "" {
+		resp.Diagnostics.AddError("Invalid configuration", "initiator_id and nickname are required")
+		return
+	}
+
+	if err := r.setInitiator(ctx, initID, nickname, plan.Profile); err != nil {
+		resp.Diagnostics.AddError("Unable to update initiator", err.Error())
+		return
+	}
+
+	initiator, err := r.findInitiator(ctx, initID, nickname)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to read initiator after update", err.Error())
+		return
+	}
+
+	newState, diag := initiatorStateFromModel(ctx, plan, initiator)
+	resp.Diagnostics.Append(diag...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &newState)...)
+}
+
+func (r *initiatorResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var state initiatorResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if r.client == nil {
+		resp.Diagnostics.AddError("Provider not configured", "Missing MSA client")
+		return
+	}
+
+	if state.AllowDestroy.IsNull() || !state.AllowDestroy.ValueBool() {
+		resp.Diagnostics.AddError(
+			"Initiator deletion not permitted",
+			"Set allow_destroy = true to permit initiator nickname deletion.",
+		)
+		return
+	}
+
+	initID := strings.TrimSpace(state.InitiatorID.ValueString())
+	if initID == "" {
+		resp.Diagnostics.AddError("Invalid state", "initiator_id is required for deletion")
+		return
+	}
+
+	_, err := r.client.Execute(ctx, "delete", "initiator-nickname", initID)
+	if err != nil {
+		resp.Diagnostics.AddError("Unable to delete initiator nickname", err.Error())
+		return
+	}
+}
+
+func (r *initiatorResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("initiator_id"), req.ID)...)
+}
+
+var errInitiatorNotFound = errors.New("initiator not found")
+
+func (r *initiatorResource) findInitiator(ctx context.Context, id, nickname string) (*msa.Initiator, error) {
+	response, err := r.client.Execute(ctx, "show", "initiators")
+	if err != nil {
+		return nil, err
+	}
+
+	initiators := msa.InitiatorsFromResponse(response)
+	for _, initiator := range initiators {
+		if id != "" && strings.EqualFold(initiator.ID, id) {
+			return &initiator, nil
+		}
+	}
+	for _, initiator := range initiators {
+		if nickname != "" && strings.EqualFold(initiator.Nickname, nickname) {
+			return &initiator, nil
+		}
+	}
+	return nil, errInitiatorNotFound
+}
+
+func (r *initiatorResource) setInitiator(ctx context.Context, id, nickname string, profile types.String) error {
+	parts := []string{"set", "initiator", "id", id, "nickname", nickname}
+	if !profile.IsNull() && !profile.IsUnknown() && strings.TrimSpace(profile.ValueString()) != "" {
+		parts = append(parts, "profile", profile.ValueString())
+	}
+
+	_, err := r.client.Execute(ctx, parts...)
+	return err
+}
+
+func initiatorStateFromModel(ctx context.Context, model initiatorResourceModel, initiator *msa.Initiator) (initiatorResourceModel, diag.Diagnostics) {
+	state := model
+	var diags diag.Diagnostics
+
+	state.InitiatorID = types.StringValue(initiator.ID)
+	state.ID = types.StringValue(initiator.ID)
+	if initiator.Nickname != "" {
+		state.Nickname = types.StringValue(initiator.Nickname)
+	}
+	if initiator.Profile != "" {
+		state.Profile = types.StringValue(initiator.Profile)
+	}
+	if initiator.HostID != "" {
+		state.HostID = types.StringValue(initiator.HostID)
+	}
+	if initiator.HostKey != "" {
+		state.HostKey = types.StringValue(initiator.HostKey)
+	}
+
+	propsValue, diag := types.MapValueFrom(ctx, types.StringType, initiator.Properties)
+	if diag.HasError() {
+		diags.Append(diag...)
+		return state, diags
+	}
+	state.Properties = propsValue
+
+	return state, diags
+}


### PR DESCRIPTION
Fixes #6.\n\n- Add host, initiator, and host initiator membership resources.\n- Parse host-groups/initiators responses (nested XML) with tests and fixtures.\n- Update host data source and provider registration.\n- Add README/examples for host and initiator workflows.\n\nTests: go test ./...
?   	github.com/d3vi1/tf-provider-hpe-msa/cmd/tf-provider-hpe-msa	[no test files]
ok  	github.com/d3vi1/tf-provider-hpe-msa/internal/msa	(cached)
ok  	github.com/d3vi1/tf-provider-hpe-msa/internal/provider	(cached) (local).