### PR TITLE
Validate host name length

### DIFF
--- a/internal/provider/resource_host.go
+++ b/internal/provider/resource_host.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -57,6 +58,9 @@ func (r *hostResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 			"name": schema.StringAttribute{
 				Description: "Host name.",
 				Required:    true,
+				Validators: []validator.String{
+					hostNameValidator{},
+				},
 			},
 			"initiators": schema.SetAttribute{
 				Description: "Initiator IDs or nicknames to seed the host (comma-free values).",

--- a/internal/provider/resource_host_initiator.go
+++ b/internal/provider/resource_host_initiator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -45,6 +46,9 @@ func (r *hostInitiatorResource) Schema(_ context.Context, _ resource.SchemaReque
 			"host_name": schema.StringAttribute{
 				Description: "Host name.",
 				Required:    true,
+				Validators: []validator.String{
+					hostNameValidator{},
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -56,5 +57,25 @@ func TestInitiatorIDValidatorRejectsEmpty(t *testing.T) {
 	v.ValidateString(context.Background(), req, resp)
 	if !resp.Diagnostics.HasError() {
 		t.Fatalf("expected diagnostics for empty initiator_id")
+	}
+}
+
+func TestHostNameValidatorLength(t *testing.T) {
+	v := hostNameValidator{}
+
+	valid := strings.Repeat("h", maxHostNameLength)
+	req := validator.StringRequest{ConfigValue: types.StringValue(valid)}
+	resp := &validator.StringResponse{}
+	v.ValidateString(context.Background(), req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("unexpected diagnostics for valid host_name: %v", resp.Diagnostics)
+	}
+
+	invalid := strings.Repeat("h", maxHostNameLength+1)
+	req = validator.StringRequest{ConfigValue: types.StringValue(invalid)}
+	resp = &validator.StringResponse{}
+	v.ValidateString(context.Background(), req, resp)
+	if !resp.Diagnostics.HasError() {
+		t.Fatalf("expected diagnostics for oversized host_name")
 	}
 }


### PR DESCRIPTION
Fixes #34.

- Add host_name validator (trimmed length 1-255) for host resources.
- Add tests for host name validation.

Tests:
- go test ./...