### PR TITLE
Expose volume SCSI WWN

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ resource "hpe_msa_volume" "example" {
 
 If `pool`/`vdisk` is omitted and the array reports exactly one pool, the provider will use that pool automatically.
 
+The volume resource also exposes `scsi_wwn`, which surfaces the host-visible SCSI/NAA identifier reported by the array for stable `/dev/disk/by-id` usage.
+
 Import by serial number:
 
 ```bash

--- a/internal/msa/testdata/show_volumes.xml
+++ b/internal/msa/testdata/show_volumes.xml
@@ -10,6 +10,7 @@
     <PROPERTY name="volume-name" type="string">vol01</PROPERTY>
     <PROPERTY name="serial-number" type="string">SN123</PROPERTY>
     <PROPERTY name="durable-id" type="string">V1</PROPERTY>
+    <PROPERTY name="wwn" type="string">600c0ff0000000000000000000000001</PROPERTY>
     <PROPERTY name="storage-poolname" type="string">pool-a</PROPERTY>
     <PROPERTY name="virtual-diskname" type="string">pool-a</PROPERTY>
     <PROPERTY name="size" type="string">100 GB</PROPERTY>

--- a/internal/msa/volume.go
+++ b/internal/msa/volume.go
@@ -6,6 +6,7 @@ type Volume struct {
 	Name         string
 	SerialNumber string
 	DurableID    string
+	WWN          string
 	PoolName     string
 	VDiskName    string
 	Size         string
@@ -39,6 +40,7 @@ func volumeFromObject(obj Object) Volume {
 		Name:         firstNonEmpty(props["volume-name"], props["name"], obj.Name),
 		SerialNumber: props["serial-number"],
 		DurableID:    props["durable-id"],
+		WWN:          firstNonEmpty(props["wwn"], props["volume-wwn"], props["volume-wwid"]),
 		PoolName:     firstNonEmpty(props["storage-pool-name"], props["storage-poolname"], props["pool-name"]),
 		VDiskName:    firstNonEmpty(props["virtual-disk-name"], props["virtual-diskname"], props["vdisk-name"]),
 		Size:         props["size"],

--- a/internal/msa/volume_test.go
+++ b/internal/msa/volume_test.go
@@ -24,6 +24,9 @@ func TestVolumesFromResponse(t *testing.T) {
 	if volume.DurableID != "V1" {
 		t.Fatalf("unexpected durable id: %s", volume.DurableID)
 	}
+	if volume.WWN != "600c0ff0000000000000000000000001" {
+		t.Fatalf("unexpected wwn: %s", volume.WWN)
+	}
 	if volume.PoolName != "pool-a" {
 		t.Fatalf("unexpected pool name: %s", volume.PoolName)
 	}

--- a/internal/provider/datasource_volume.go
+++ b/internal/provider/datasource_volume.go
@@ -30,6 +30,7 @@ type volumeDataSourceModel struct {
 	SerialNumber types.String `tfsdk:"serial_number"`
 	DurableID    types.String `tfsdk:"durable_id"`
 	WWID         types.String `tfsdk:"wwid"`
+	SCSIWWN      types.String `tfsdk:"scsi_wwn"`
 	Pool         types.String `tfsdk:"pool"`
 	VDisk        types.String `tfsdk:"vdisk"`
 	Size         types.String `tfsdk:"size"`
@@ -65,6 +66,10 @@ func (d *volumeDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 			},
 			"wwid": schema.StringAttribute{
 				Description: "WWID derived from the array (serial number).",
+				Computed:    true,
+			},
+			"scsi_wwn": schema.StringAttribute{
+				Description: "Host-visible SCSI WWN/NAA identifier reported by the array.",
 				Computed:    true,
 			},
 			"pool": schema.StringAttribute{
@@ -177,6 +182,11 @@ func (d *volumeDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	data.SerialNumber = types.StringValue(volume.SerialNumber)
 	data.DurableID = types.StringValue(volume.DurableID)
 	data.WWID = types.StringValue(volume.SerialNumber)
+	if volume.WWN != "" {
+		data.SCSIWWN = types.StringValue(volume.WWN)
+	} else {
+		data.SCSIWWN = types.StringNull()
+	}
 	data.Pool = types.StringValue(volume.PoolName)
 	data.VDisk = types.StringValue(volume.VDiskName)
 	data.Size = types.StringValue(volume.Size)

--- a/internal/provider/resource_volume.go
+++ b/internal/provider/resource_volume.go
@@ -39,6 +39,7 @@ type volumeResourceModel struct {
 	DurableID    types.String `tfsdk:"durable_id"`
 	SerialNumber types.String `tfsdk:"serial_number"`
 	WWID         types.String `tfsdk:"wwid"`
+	SCSIWWN      types.String `tfsdk:"scsi_wwn"`
 	AllowDestroy types.Bool   `tfsdk:"allow_destroy"`
 }
 
@@ -93,6 +94,10 @@ func (r *volumeResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			},
 			"wwid": schema.StringAttribute{
 				Description: "WWID derived from the array (serial number).",
+				Computed:    true,
+			},
+			"scsi_wwn": schema.StringAttribute{
+				Description: "Host-visible SCSI WWN/NAA identifier reported by the array.",
 				Computed:    true,
 			},
 			"allow_destroy": schema.BoolAttribute{
@@ -437,6 +442,11 @@ func volumeStateFromModel(model volumeResourceModel, volume *msa.Volume) volumeR
 		state.SerialNumber = types.StringValue(volume.SerialNumber)
 		state.ID = types.StringValue(volume.SerialNumber)
 		state.WWID = types.StringValue(volume.SerialNumber)
+	}
+	if volume.WWN != "" {
+		state.SCSIWWN = types.StringValue(volume.WWN)
+	} else {
+		state.SCSIWWN = types.StringNull()
 	}
 
 	return state


### PR DESCRIPTION
Fixes #37.

## Summary
- parse volume WWN/host-visible identifier from XML responses
- expose computed scsi_wwn on volume resource and data source
- update fixture + unit test and README

## Testing
- go test ./...
- make lint (fails: golangci-lint not installed locally)