### PR TITLE
Harden host_group references and add stress tests

### DIFF
--- a/internal/provider/resource_host.go
+++ b/internal/provider/resource_host.go
@@ -74,6 +74,9 @@ func (r *hostResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Description: "Optional host group name to add the host to.",
 				Optional:    true,
 				Computed:    true,
+				Validators: []validator.String{
+					hostGroupNameValidator{},
+				},
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},

--- a/internal/provider/resource_volume_mapping.go
+++ b/internal/provider/resource_volume_mapping.go
@@ -344,6 +344,10 @@ func buildTargetSpec(targetType types.String, targetName types.String) (string, 
 	case "host":
 		return fmt.Sprintf("%s.*", nameValue), diags
 	case "host_group":
+		if err := validateHostGroupNameValue(nameValue); err != nil {
+			diags.AddError("Invalid target_name", err.Error())
+			return "", diags
+		}
 		return fmt.Sprintf("%s.*.*", nameValue), diags
 	case "initiator":
 		return nameValue, diags

--- a/internal/provider/resource_volume_mapping_test.go
+++ b/internal/provider/resource_volume_mapping_test.go
@@ -32,6 +32,13 @@ func TestBuildTargetSpec(t *testing.T) {
 	}
 }
 
+func TestBuildTargetSpecInvalidHostGroupName(t *testing.T) {
+	_, diags := buildTargetSpec(stringValueOrNull("host_group"), stringValueOrNull("bad,name"))
+	if !diags.HasError() {
+		t.Fatalf("expected diagnostics for invalid host_group name")
+	}
+}
+
 func TestNormalizeAccess(t *testing.T) {
 	cases := map[string]string{
 		"rw":         "read-write",

--- a/internal/provider/resource_volume_test.go
+++ b/internal/provider/resource_volume_test.go
@@ -172,3 +172,23 @@ func TestPoolNamesFromResponse(t *testing.T) {
 		t.Fatalf("unexpected pool names: %v", names)
 	}
 }
+
+func TestVolumeStateFromModelSCSIWWN(t *testing.T) {
+	model := volumeResourceModel{}
+	volume := &msa.Volume{
+		Name:         "vol01",
+		SerialNumber: "SN123",
+		WWN:          "600c0ff0000000000000000000000001",
+	}
+
+	state := volumeStateFromModel(model, volume)
+	if state.SCSIWWN.IsNull() || state.SCSIWWN.ValueString() != volume.WWN {
+		t.Fatalf("expected scsi_wwn to be set from volume wwn")
+	}
+
+	volume.WWN = ""
+	state = volumeStateFromModel(model, volume)
+	if !state.SCSIWWN.IsNull() {
+		t.Fatalf("expected scsi_wwn to be null when wwn missing")
+	}
+}

--- a/internal/provider/validators_test.go
+++ b/internal/provider/validators_test.go
@@ -142,3 +142,19 @@ func TestHostNamesSetValidator(t *testing.T) {
 		t.Fatalf("expected diagnostics for invalid hosts")
 	}
 }
+
+func TestValidateHostGroupNameValue(t *testing.T) {
+	valid := []string{"GroupA", "Group 1"}
+	for _, value := range valid {
+		if err := validateHostGroupNameValue(value); err != nil {
+			t.Fatalf("unexpected error for valid host group name %q: %v", value, err)
+		}
+	}
+
+	invalid := []string{"", "bad,name", "bad.name", "bad<name"}
+	for _, value := range invalid {
+		if err := validateHostGroupNameValue(value); err == nil {
+			t.Fatalf("expected error for invalid host group name %q", value)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #40.

## Summary
- validate host_group names when referenced by hpe_msa_host and volume mappings
- add stress tests for host_group name validation + mapping target validation
- add scsi_wwn state coverage in volume unit tests

## Testing
- go test ./...
- make lint (fails: golangci-lint not installed locally)