### PR TITLE
Expose scsi_wwn on clone resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ resource "hpe_msa_clone" "example" {
 }
 ```
 
+The clone resource also exposes `scsi_wwn`, which surfaces the host-visible SCSI/NAA identifier reported by the array.
+
 Import by serial number:
 
 ```bash

--- a/internal/provider/resource_clone.go
+++ b/internal/provider/resource_clone.go
@@ -37,6 +37,7 @@ type cloneResourceModel struct {
 	DurableID       types.String `tfsdk:"durable_id"`
 	SerialNumber    types.String `tfsdk:"serial_number"`
 	WWID            types.String `tfsdk:"wwid"`
+	SCSIWWN         types.String `tfsdk:"scsi_wwn"`
 	AllowDestroy    types.Bool   `tfsdk:"allow_destroy"`
 }
 
@@ -92,6 +93,10 @@ func (r *cloneResource) Schema(_ context.Context, _ resource.SchemaRequest, resp
 			},
 			"wwid": schema.StringAttribute{
 				Description: "WWID derived from the array (serial number).",
+				Computed:    true,
+			},
+			"scsi_wwn": schema.StringAttribute{
+				Description: "Host-visible SCSI WWN/NAA identifier reported by the array.",
 				Computed:    true,
 			},
 			"allow_destroy": schema.BoolAttribute{
@@ -354,6 +359,11 @@ func cloneStateFromModel(model cloneResourceModel, volume *msa.Volume) cloneReso
 		state.SerialNumber = types.StringValue(volume.SerialNumber)
 		state.ID = types.StringValue(volume.SerialNumber)
 		state.WWID = types.StringValue(volume.SerialNumber)
+	}
+	if volume.WWN != "" {
+		state.SCSIWWN = types.StringValue(volume.WWN)
+	} else {
+		state.SCSIWWN = types.StringNull()
 	}
 
 	return state

--- a/internal/provider/resource_clone_test.go
+++ b/internal/provider/resource_clone_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"testing"
 
+	"github.com/d3vi1/tf-provider-hpe-msa/internal/msa"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
@@ -38,5 +39,25 @@ func TestResolveCloneSnapshot(t *testing.T) {
 				t.Fatalf("expected %q, got %q", tc.expectValue, value)
 			}
 		})
+	}
+}
+
+func TestCloneStateFromModelSCSIWWN(t *testing.T) {
+	model := cloneResourceModel{}
+	volume := &msa.Volume{
+		Name:         "clone01",
+		SerialNumber: "SNCLONE1",
+		WWN:          "600c0ff0000000000000000000000002",
+	}
+
+	state := cloneStateFromModel(model, volume)
+	if state.SCSIWWN.IsNull() || state.SCSIWWN.ValueString() != volume.WWN {
+		t.Fatalf("expected scsi_wwn to be set from volume wwn")
+	}
+
+	volume.WWN = ""
+	state = cloneStateFromModel(model, volume)
+	if !state.SCSIWWN.IsNull() {
+		t.Fatalf("expected scsi_wwn to be null when wwn missing")
 	}
 }


### PR DESCRIPTION
Fixes #46.

## Summary
- surface scsi_wwn on hpe_msa_clone from XML volume WWN
- add unit test for clone state mapping
- document scsi_wwn in README clone section

## Testing
- go test ./...
- make lint (fails: golangci-lint not installed locally)