### PR TITLE
Handle Info response types as success

### DIFF
--- a/internal/msa/xml.go
+++ b/internal/msa/xml.go
@@ -74,6 +74,12 @@ func (r Response) Status() (Status, bool) {
 }
 
 func (s Status) Success() bool {
+	if s.ResponseTypeNumeric == 1 || strings.EqualFold(s.ResponseType, "error") {
+		return false
+	}
+	if s.ReturnCode == 0 {
+		return true
+	}
 	if s.ResponseTypeNumeric != 0 {
 		return false
 	}

--- a/internal/msa/xml_test.go
+++ b/internal/msa/xml_test.go
@@ -1,0 +1,56 @@
+package msa
+
+import "testing"
+
+func TestStatusSuccess(t *testing.T) {
+	tests := []struct {
+		name   string
+		status Status
+		want   bool
+	}{
+		{
+			name: "success response-type",
+			status: Status{
+				ResponseType:        "Success",
+				ResponseTypeNumeric: 0,
+				ReturnCode:          1,
+			},
+			want: true,
+		},
+		{
+			name: "info response-type with return-code 0",
+			status: Status{
+				ResponseType:        "Info",
+				ResponseTypeNumeric: 2,
+				ReturnCode:          0,
+			},
+			want: true,
+		},
+		{
+			name: "error response-type",
+			status: Status{
+				ResponseType:        "Error",
+				ResponseTypeNumeric: 1,
+				ReturnCode:          0,
+			},
+			want: false,
+		},
+		{
+			name: "info response-type nonzero return-code",
+			status: Status{
+				ResponseType:        "Info",
+				ResponseTypeNumeric: 2,
+				ReturnCode:          5,
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := test.status.Success(); got != test.want {
+				t.Fatalf("unexpected success result: got %v, want %v", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary\n- treat return-code 0 as success unless response indicates Error\n- keep existing Success response behavior for return-code 1\n- add Status.Success unit tests for Info/Error cases\n\n## Testing\n- go test ./...\n\nCloses #50