### PR TITLE
Handle clone conflict retries via active volume-copy ETA (#52)

### DIFF
--- a/internal/msa/client_test.go
+++ b/internal/msa/client_test.go
@@ -161,6 +161,151 @@ func TestExecuteRetriesOnSessionError(t *testing.T) {
 	}
 }
 
+func TestFindActiveVolumeCopyJobWithETA(t *testing.T) {
+	fixture := readFixture(t, "show_volume_copy_active_eta.xml")
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/login/"):
+			w.Header().Set("Content-Type", "text/xml")
+			_, _ = w.Write(loginResponse("session-eta"))
+		case r.URL.Path == "/api/show/volume-copy":
+			w.Header().Set("Content-Type", "text/xml")
+			_, _ = w.Write(fixture)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	client.retryConfig = RetryConfig{MaxAttempts: 1}
+
+	job, err := client.FindActiveVolumeCopyJob(context.Background(), "snap-prod-001", "clone-prod-001")
+	if err != nil {
+		t.Fatalf("unexpected lookup error: %v", err)
+	}
+	if job == nil {
+		t.Fatalf("expected active volume-copy job")
+	}
+	if job.ID != "job-77" {
+		t.Fatalf("expected job-77, got %q", job.ID)
+	}
+	if !job.HasETA {
+		t.Fatalf("expected ETA to be available")
+	}
+	if job.ETA != 2*time.Minute {
+		t.Fatalf("expected 2m ETA, got %s", job.ETA)
+	}
+}
+
+func TestFindActiveVolumeCopyJobWithoutETA(t *testing.T) {
+	fixture := readFixture(t, "show_volume_copy_active_no_eta.xml")
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/login/"):
+			w.Header().Set("Content-Type", "text/xml")
+			_, _ = w.Write(loginResponse("session-no-eta"))
+		case r.URL.Path == "/api/show/volume-copy":
+			w.Header().Set("Content-Type", "text/xml")
+			_, _ = w.Write(fixture)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	client.retryConfig = RetryConfig{MaxAttempts: 1}
+
+	job, err := client.FindActiveVolumeCopyJob(context.Background(), "snap-prod-001", "clone-prod-001")
+	if err != nil {
+		t.Fatalf("unexpected lookup error: %v", err)
+	}
+	if job == nil {
+		t.Fatalf("expected active volume-copy job")
+	}
+	if job.ID != "job-90" {
+		t.Fatalf("expected job-90, got %q", job.ID)
+	}
+	if job.HasETA {
+		t.Fatalf("did not expect ETA to be available")
+	}
+	if job.ETARaw != "N/A" {
+		t.Fatalf("expected raw ETA marker N/A, got %q", job.ETARaw)
+	}
+}
+
+func TestFindActiveVolumeCopyJobFallsBackToVolumeCopiesCommand(t *testing.T) {
+	fixture := readFixture(t, "show_volume_copy_active_eta.xml")
+	volumeCopyCalls := 0
+	volumeCopiesCalls := 0
+
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.HasPrefix(r.URL.Path, "/api/login/"):
+			w.Header().Set("Content-Type", "text/xml")
+			_, _ = w.Write(loginResponse("session-fallback"))
+		case r.URL.Path == "/api/show/volume-copy":
+			volumeCopyCalls++
+			w.Header().Set("Content-Type", "text/xml")
+			_, _ = w.Write(commandErrorResponse("Unsupported command"))
+		case r.URL.Path == "/api/show/volume-copies":
+			volumeCopiesCalls++
+			w.Header().Set("Content-Type", "text/xml")
+			_, _ = w.Write(fixture)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server.URL)
+	client.retryConfig = RetryConfig{MaxAttempts: 1}
+
+	job, err := client.FindActiveVolumeCopyJob(context.Background(), "snap-prod-001", "clone-prod-001")
+	if err != nil {
+		t.Fatalf("unexpected lookup error: %v", err)
+	}
+	if job == nil {
+		t.Fatalf("expected active volume-copy job")
+	}
+	if volumeCopyCalls != 1 {
+		t.Fatalf("expected one volume-copy call, got %d", volumeCopyCalls)
+	}
+	if volumeCopiesCalls != 1 {
+		t.Fatalf("expected one volume-copies call, got %d", volumeCopiesCalls)
+	}
+}
+
+func TestParseVolumeCopyETA(t *testing.T) {
+	cases := []struct {
+		name      string
+		value     string
+		expected  time.Duration
+		expectETA bool
+	}{
+		{name: "hhmmss", value: "00:01:30", expected: 90 * time.Second, expectETA: true},
+		{name: "seconds", value: "120", expected: 120 * time.Second, expectETA: true},
+		{name: "duration", value: "2m 30s", expected: 150 * time.Second, expectETA: true},
+		{name: "human", value: "3 minutes 5 seconds", expected: 185 * time.Second, expectETA: true},
+		{name: "missing", value: "N/A", expected: 0, expectETA: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, ok := parseVolumeCopyETA(tc.value)
+			if ok != tc.expectETA {
+				t.Fatalf("expected ETA available %t, got %t", tc.expectETA, ok)
+			}
+			if result != tc.expected {
+				t.Fatalf("expected %s, got %s", tc.expected, result)
+			}
+		})
+	}
+}
+
 func TestCommandPath(t *testing.T) {
 	path := CommandPath("show", "pools")
 	if path != "/api/show/pools" {
@@ -192,6 +337,18 @@ func loginResponse(sessionKey string) []byte {
     <PROPERTY name="response-type-numeric" type="uint32">0</PROPERTY>
     <PROPERTY name="response" type="string">` + sessionKey + `</PROPERTY>
     <PROPERTY name="return-code" type="sint32">1</PROPERTY>
+  </OBJECT>
+</RESPONSE>`)
+}
+
+func commandErrorResponse(message string) []byte {
+	return []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<RESPONSE VERSION="L100">
+  <OBJECT basetype="status" name="status" oid="1">
+    <PROPERTY name="response-type" type="string">Error</PROPERTY>
+    <PROPERTY name="response-type-numeric" type="uint32">1</PROPERTY>
+    <PROPERTY name="response" type="string">` + message + `</PROPERTY>
+    <PROPERTY name="return-code" type="sint32">-1</PROPERTY>
   </OBJECT>
 </RESPONSE>`)
 }

--- a/internal/msa/testdata/show_volume_copy_active_eta.xml
+++ b/internal/msa/testdata/show_volume_copy_active_eta.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RESPONSE VERSION="L100" REQUEST="show volume-copy">
+  <OBJECT basetype="status" name="status" oid="1">
+    <PROPERTY name="response-type" type="string">Success</PROPERTY>
+    <PROPERTY name="response-type-numeric" type="uint32">0</PROPERTY>
+    <PROPERTY name="response" type="string">OK</PROPERTY>
+    <PROPERTY name="return-code" type="sint32">0</PROPERTY>
+  </OBJECT>
+  <OBJECT basetype="volume-copy" name="volume-copy" oid="77">
+    <PROPERTY name="job-id" type="string">job-77</PROPERTY>
+    <PROPERTY name="source-volume-name" type="string">snap-prod-001</PROPERTY>
+    <PROPERTY name="destination-volume-name" type="string">clone-prod-001</PROPERTY>
+    <PROPERTY name="copy-status" type="string">In Progress</PROPERTY>
+    <PROPERTY name="estimated-time-remaining" type="string">00:02:00</PROPERTY>
+    <PROPERTY name="progress" type="string">51%</PROPERTY>
+  </OBJECT>
+  <OBJECT basetype="volume-copy" name="volume-copy" oid="78">
+    <PROPERTY name="job-id" type="string">job-78</PROPERTY>
+    <PROPERTY name="source-volume-name" type="string">snap-prod-000</PROPERTY>
+    <PROPERTY name="destination-volume-name" type="string">clone-prod-000</PROPERTY>
+    <PROPERTY name="copy-status" type="string">Completed</PROPERTY>
+    <PROPERTY name="estimated-time-remaining" type="string">00:00:00</PROPERTY>
+    <PROPERTY name="progress" type="string">100%</PROPERTY>
+  </OBJECT>
+</RESPONSE>

--- a/internal/msa/testdata/show_volume_copy_active_no_eta.xml
+++ b/internal/msa/testdata/show_volume_copy_active_no_eta.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<RESPONSE VERSION="L100" REQUEST="show volume-copy">
+  <OBJECT basetype="status" name="status" oid="1">
+    <PROPERTY name="response-type" type="string">Success</PROPERTY>
+    <PROPERTY name="response-type-numeric" type="uint32">0</PROPERTY>
+    <PROPERTY name="response" type="string">OK</PROPERTY>
+    <PROPERTY name="return-code" type="sint32">0</PROPERTY>
+  </OBJECT>
+  <OBJECT basetype="volume-copy" name="volume-copy" oid="90">
+    <PROPERTY name="id" type="string">job-90</PROPERTY>
+    <PROPERTY name="source-volume" type="string">snap-prod-001</PROPERTY>
+    <PROPERTY name="destination-volume" type="string">clone-prod-001</PROPERTY>
+    <PROPERTY name="status" type="string">Running</PROPERTY>
+    <PROPERTY name="remaining-time" type="string">N/A</PROPERTY>
+    <PROPERTY name="copy-progress" type="string">9%</PROPERTY>
+  </OBJECT>
+  <OBJECT basetype="volume-copy" name="volume-copy" oid="91">
+    <PROPERTY name="id" type="string">job-91</PROPERTY>
+    <PROPERTY name="source-volume" type="string">snap-prod-002</PROPERTY>
+    <PROPERTY name="destination-volume" type="string">clone-prod-002</PROPERTY>
+    <PROPERTY name="status" type="string">Running</PROPERTY>
+    <PROPERTY name="remaining-time" type="string">N/A</PROPERTY>
+    <PROPERTY name="copy-progress" type="string">3%</PROPERTY>
+  </OBJECT>
+</RESPONSE>

--- a/internal/msa/volume_copy.go
+++ b/internal/msa/volume_copy.go
@@ -1,0 +1,371 @@
+package msa
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+var showVolumeCopyCommands = [][]string{
+	{"show", "volume-copy"},
+	{"show", "volume-copies"},
+}
+
+var volumeCopyJobIDKeys = []string{
+	"job-id",
+	"copy-job-id",
+	"serial-number",
+	"id",
+}
+
+var volumeCopySourceKeys = []string{
+	"source-volume-name",
+	"source-volume",
+	"source-name",
+	"source",
+	"base-volume",
+	"base-volume-name",
+	"master-volume-name",
+}
+
+var volumeCopyTargetKeys = []string{
+	"destination-volume-name",
+	"destination-volume",
+	"destination-name",
+	"destination",
+	"target-volume-name",
+	"target-volume",
+	"target-name",
+	"target",
+	"volume-name",
+	"name",
+}
+
+var volumeCopyStatusKeys = []string{
+	"copy-status",
+	"status",
+	"state",
+	"job-status",
+	"progress-status",
+}
+
+var volumeCopyETAKeys = []string{
+	"estimated-time-remaining",
+	"estimated-time-to-completion",
+	"estimated-time-left",
+	"time-remaining",
+	"time-to-complete",
+	"remaining-time",
+	"eta",
+	"seconds-to-completion",
+	"estimated-seconds-to-complete",
+}
+
+var volumeCopyProgressKeys = []string{
+	"progress",
+	"progress-percent",
+	"copy-progress",
+	"percent-complete",
+}
+
+type VolumeCopyJob struct {
+	ID         string
+	Source     string
+	Target     string
+	Status     string
+	ETARaw     string
+	ETA        time.Duration
+	HasETA     bool
+	Active     bool
+	Properties map[string]string
+}
+
+func (c *Client) FindActiveVolumeCopyJob(ctx context.Context, sourceHint, targetHint string) (*VolumeCopyJob, error) {
+	var commandErrs []error
+
+	for _, parts := range showVolumeCopyCommands {
+		response, err := c.Execute(ctx, parts...)
+		if err != nil {
+			commandErrs = append(commandErrs, fmt.Errorf("%s: %w", strings.Join(parts, " "), err))
+			continue
+		}
+
+		jobs := VolumeCopyJobsFromResponse(response)
+		job := selectBestActiveVolumeCopyJob(jobs, sourceHint, targetHint)
+		if job != nil {
+			return job, nil
+		}
+		return nil, nil
+	}
+
+	if len(commandErrs) == 0 {
+		return nil, nil
+	}
+	return nil, errors.Join(commandErrs...)
+}
+
+func VolumeCopyJobsFromResponse(response Response) []VolumeCopyJob {
+	jobs := make([]VolumeCopyJob, 0)
+	for _, obj := range response.ObjectsWithoutStatus() {
+		if !isVolumeCopyObject(obj) {
+			continue
+		}
+		jobs = append(jobs, volumeCopyJobFromObject(obj))
+	}
+	return jobs
+}
+
+func selectBestActiveVolumeCopyJob(jobs []VolumeCopyJob, sourceHint, targetHint string) *VolumeCopyJob {
+	normalizedSourceHint := strings.ToLower(strings.TrimSpace(sourceHint))
+	normalizedTargetHint := strings.ToLower(strings.TrimSpace(targetHint))
+
+	bestScore := -1
+	var best *VolumeCopyJob
+	for i := range jobs {
+		job := jobs[i]
+		if !job.Active {
+			continue
+		}
+
+		score := 0
+		if normalizedSourceHint != "" && matchesVolumeCopyHint(job.Source, normalizedSourceHint) {
+			score += 4
+		}
+		if normalizedTargetHint != "" && matchesVolumeCopyHint(job.Target, normalizedTargetHint) {
+			score += 6
+		}
+		if job.HasETA {
+			score += 2
+		}
+		if strings.TrimSpace(job.ID) != "" {
+			score++
+		}
+
+		if score > bestScore {
+			bestScore = score
+			candidate := job
+			best = &candidate
+		}
+	}
+
+	return best
+}
+
+func matchesVolumeCopyHint(value, hint string) bool {
+	if hint == "" {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(value), hint)
+}
+
+func isVolumeCopyObject(obj Object) bool {
+	baseType := strings.ToLower(strings.TrimSpace(obj.BaseType))
+	name := strings.ToLower(strings.TrimSpace(obj.Name))
+	if strings.Contains(baseType, "volume-copy") || strings.Contains(name, "volume-copy") {
+		return true
+	}
+	if strings.Contains(baseType, "copy") && strings.Contains(baseType, "volume") {
+		return true
+	}
+
+	props := obj.PropertyMap()
+	return hasAnyProperty(props, volumeCopySourceKeys...) && hasAnyProperty(props, volumeCopyTargetKeys...)
+}
+
+func volumeCopyJobFromObject(obj Object) VolumeCopyJob {
+	props := obj.PropertyMap()
+	etaRaw := firstPropertyValue(props, volumeCopyETAKeys...)
+	eta, hasETA := parseVolumeCopyETA(etaRaw)
+	status := firstPropertyValue(props, volumeCopyStatusKeys...)
+
+	job := VolumeCopyJob{
+		ID:         firstNonEmpty(firstPropertyValue(props, volumeCopyJobIDKeys...), strings.TrimSpace(obj.OID)),
+		Source:     firstPropertyValue(props, volumeCopySourceKeys...),
+		Target:     firstPropertyValue(props, volumeCopyTargetKeys...),
+		Status:     status,
+		ETARaw:     etaRaw,
+		ETA:        eta,
+		HasETA:     hasETA,
+		Active:     isVolumeCopyJobActive(status, props),
+		Properties: props,
+	}
+
+	return job
+}
+
+func hasAnyProperty(props map[string]string, keys ...string) bool {
+	for _, key := range keys {
+		if value := strings.TrimSpace(props[key]); value != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func firstPropertyValue(props map[string]string, keys ...string) string {
+	for _, key := range keys {
+		if value := strings.TrimSpace(props[key]); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func isVolumeCopyJobActive(status string, props map[string]string) bool {
+	normalizedStatus := strings.ToLower(strings.TrimSpace(status))
+	if normalizedStatus != "" {
+		for _, terminal := range []string{
+			"complete",
+			"completed",
+			"success",
+			"succeeded",
+			"failed",
+			"failure",
+			"error",
+			"aborted",
+			"canceled",
+			"cancelled",
+			"stopped",
+			"done",
+		} {
+			if strings.Contains(normalizedStatus, terminal) {
+				return false
+			}
+		}
+
+		for _, active := range []string{
+			"progress",
+			"running",
+			"copy",
+			"active",
+			"queued",
+			"pending",
+			"starting",
+			"in-progress",
+		} {
+			if strings.Contains(normalizedStatus, active) {
+				return true
+			}
+		}
+	}
+
+	progress := firstPropertyValue(props, volumeCopyProgressKeys...)
+	if percent, ok := parseProgressPercent(progress); ok {
+		return percent < 100
+	}
+
+	return true
+}
+
+func parseProgressPercent(value string) (float64, bool) {
+	trimmed := strings.TrimSpace(strings.TrimSuffix(value, "%"))
+	if trimmed == "" {
+		return 0, false
+	}
+	parsed, err := strconv.ParseFloat(trimmed, 64)
+	if err != nil {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func parseVolumeCopyETA(value string) (time.Duration, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return 0, false
+	}
+
+	normalized := strings.ToLower(value)
+	switch normalized {
+	case "n/a", "na", "none", "unknown", "-", "--":
+		return 0, false
+	}
+
+	if parsed, ok := parseColonDuration(value); ok {
+		return parsed, true
+	}
+
+	if parsed, err := strconv.Atoi(value); err == nil {
+		if parsed < 0 {
+			return 0, false
+		}
+		return time.Duration(parsed) * time.Second, true
+	}
+
+	compact := strings.ReplaceAll(normalized, " ", "")
+	if parsed, err := time.ParseDuration(compact); err == nil {
+		return parsed, true
+	}
+
+	if parsed, ok := parseHumanDuration(normalized); ok {
+		return parsed, true
+	}
+
+	return 0, false
+}
+
+func parseColonDuration(value string) (time.Duration, bool) {
+	parts := strings.Split(strings.TrimSpace(value), ":")
+	if len(parts) != 2 && len(parts) != 3 {
+		return 0, false
+	}
+
+	values := make([]int, len(parts))
+	for i, part := range parts {
+		parsed, err := strconv.Atoi(strings.TrimSpace(part))
+		if err != nil || parsed < 0 {
+			return 0, false
+		}
+		values[i] = parsed
+	}
+
+	if len(values) == 2 {
+		return time.Duration(values[0])*time.Minute + time.Duration(values[1])*time.Second, true
+	}
+
+	return time.Duration(values[0])*time.Hour +
+		time.Duration(values[1])*time.Minute +
+		time.Duration(values[2])*time.Second, true
+}
+
+func parseHumanDuration(value string) (time.Duration, bool) {
+	fields := strings.Fields(value)
+	if len(fields) < 2 {
+		return 0, false
+	}
+
+	total := time.Duration(0)
+	matched := false
+	for i := 0; i < len(fields)-1; i++ {
+		amount, err := strconv.Atoi(strings.TrimSpace(fields[i]))
+		if err != nil || amount < 0 {
+			continue
+		}
+
+		unit := strings.Trim(strings.TrimSpace(fields[i+1]), ",")
+		switch {
+		case strings.HasPrefix(unit, "d"):
+			total += time.Duration(amount) * 24 * time.Hour
+		case strings.HasPrefix(unit, "h"):
+			total += time.Duration(amount) * time.Hour
+		case strings.HasPrefix(unit, "m"):
+			total += time.Duration(amount) * time.Minute
+		case strings.HasPrefix(unit, "s"):
+			total += time.Duration(amount) * time.Second
+		default:
+			continue
+		}
+
+		matched = true
+		i++
+	}
+
+	if !matched {
+		return 0, false
+	}
+
+	return total, true
+}

--- a/internal/provider/resource_clone.go
+++ b/internal/provider/resource_clone.go
@@ -311,16 +311,11 @@ type cloneConflictRetryPlanner struct {
 }
 
 func (p *cloneConflictRetryPlanner) next(job *msa.VolumeCopyJob) (time.Duration, string, bool) {
-	if p.strategy == cloneConflictRetryStrategyUnset {
-		if job != nil && job.HasETA {
-			p.strategy = cloneConflictRetryStrategyETA
-		} else {
-			p.strategy = cloneConflictRetryStrategyNoETA
-		}
-	}
-
 	if job != nil && job.HasETA {
+		p.strategy = cloneConflictRetryStrategyETA
 		p.lastETA = job.ETA
+	} else if p.strategy == cloneConflictRetryStrategyUnset {
+		p.strategy = cloneConflictRetryStrategyNoETA
 	}
 
 	switch p.strategy {

--- a/internal/provider/resource_clone.go
+++ b/internal/provider/resource_clone.go
@@ -281,6 +281,11 @@ func (r *cloneResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		return
 	}
 
+	if guardrail, ok := preDeleteVolumeUsageGuardrail(ctx, r.client, "clone", target, state.Name.ValueString(), id); ok {
+		resp.Diagnostics.AddError(guardrail.summary, guardrail.detail)
+		return
+	}
+
 	_, err := r.client.Execute(ctx, "delete", "volumes", target)
 	if err != nil {
 		if guardrail, ok := classifyVolumeDeleteError("clone", target, err); ok {

--- a/internal/provider/resource_clone_test.go
+++ b/internal/provider/resource_clone_test.go
@@ -1,7 +1,11 @@
 package provider
 
 import (
+	"context"
+	"errors"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/d3vi1/tf-provider-hpe-msa/internal/msa"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -59,5 +63,109 @@ func TestCloneStateFromModelSCSIWWN(t *testing.T) {
 	state = cloneStateFromModel(model, volume)
 	if !state.SCSIWWN.IsNull() {
 		t.Fatalf("expected scsi_wwn to be null when wwn missing")
+	}
+}
+
+func TestCloneConflictRetryPlannerETAPath(t *testing.T) {
+	planner := cloneConflictRetryPlanner{}
+	job := &msa.VolumeCopyJob{
+		HasETA: true,
+		ETA:    2 * time.Minute,
+	}
+
+	for i := 0; i < cloneCopyConflictETAMaxRetries; i++ {
+		wait, path, ok := planner.next(job)
+		if !ok {
+			t.Fatalf("expected retry on eta iteration %d", i)
+		}
+		if path != cloneRetryPathETA {
+			t.Fatalf("expected eta path, got %s", path)
+		}
+		expectedWait := 2*time.Minute + cloneCopyETASafetyBuffer
+		if wait != expectedWait {
+			t.Fatalf("expected wait %s, got %s", expectedWait, wait)
+		}
+	}
+
+	_, _, ok := planner.next(job)
+	if ok {
+		t.Fatalf("expected eta retries to stop after %d retries", cloneCopyConflictETAMaxRetries)
+	}
+}
+
+func TestCloneConflictRetryPlannerNoETAPath(t *testing.T) {
+	planner := cloneConflictRetryPlanner{}
+
+	for i, expected := range cloneCopyConflictNoETAWaits {
+		wait, path, ok := planner.next(&msa.VolumeCopyJob{ID: "job-no-eta"})
+		if !ok {
+			t.Fatalf("expected retry on no-eta iteration %d", i)
+		}
+		if path != cloneRetryPathNoETA {
+			t.Fatalf("expected no-eta path, got %s", path)
+		}
+		if wait != expected {
+			t.Fatalf("expected wait %s, got %s", expected, wait)
+		}
+	}
+
+	_, _, ok := planner.next(nil)
+	if ok {
+		t.Fatalf("expected no-eta retries to stop after %d retries", len(cloneCopyConflictNoETAWaits))
+	}
+}
+
+func TestCloneConflictContext(t *testing.T) {
+	contextState := newCloneConflictContext("source-initial", "target-initial")
+	if got := contextState.String(); !strings.Contains(got, "source=source-initial") || !strings.Contains(got, "target=target-initial") {
+		t.Fatalf("unexpected initial context: %s", got)
+	}
+
+	contextState.update(&msa.VolumeCopyJob{
+		ID:     "job-52",
+		Source: "source-job",
+		Target: "target-job",
+		HasETA: true,
+		ETA:    95 * time.Second,
+	})
+
+	got := contextState.String()
+	if !strings.Contains(got, "job id=job-52") {
+		t.Fatalf("expected job id in context, got %s", got)
+	}
+	if !strings.Contains(got, "source=source-job") {
+		t.Fatalf("expected source in context, got %s", got)
+	}
+	if !strings.Contains(got, "target=target-job") {
+		t.Fatalf("expected target in context, got %s", got)
+	}
+	if !strings.Contains(got, "eta=1m35s") {
+		t.Fatalf("expected eta in context, got %s", got)
+	}
+}
+
+func TestCloneCopyConflictErrorMatching(t *testing.T) {
+	conflictErr := msa.APIError{
+		Status: msa.Status{
+			Response: "The operation cannot be completed because it conflicts with an existing volume copy in progress.",
+		},
+	}
+	if !isCloneCopyConflictError(conflictErr) {
+		t.Fatalf("expected conflict error match")
+	}
+
+	otherErr := msa.APIError{Status: msa.Status{Response: "Some other command failure"}}
+	if isCloneCopyConflictError(otherErr) {
+		t.Fatalf("did not expect conflict match")
+	}
+}
+
+func TestSleepWithContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := sleepWithContext(ctx, 5*time.Second)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context cancellation, got %v", err)
 	}
 }

--- a/internal/provider/resource_volume_test.go
+++ b/internal/provider/resource_volume_test.go
@@ -278,7 +278,7 @@ func TestClassifyVolumeDeleteErrorInUse(t *testing.T) {
 	if guardrail.summary != "Clone deletion blocked: in use" {
 		t.Fatalf("unexpected summary: %s", guardrail.summary)
 	}
-	if !strings.Contains(guardrail.detail, "Delete dependent snapshots/clones") {
+	if !strings.Contains(guardrail.detail, "Delete the dependent objects first") {
 		t.Fatalf("expected actionable dependency detail, got %s", guardrail.detail)
 	}
 	if !strings.Contains(guardrail.detail, "clone-app-01") {

--- a/internal/provider/resource_volume_test.go
+++ b/internal/provider/resource_volume_test.go
@@ -1,7 +1,9 @@
 package provider
 
 import (
+	"errors"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/d3vi1/tf-provider-hpe-msa/internal/msa"
@@ -237,5 +239,65 @@ func TestVolumeStateFromModelSCSIWWN(t *testing.T) {
 	state = volumeStateFromModel(model, volume)
 	if !state.SCSIWWN.IsNull() {
 		t.Fatalf("expected scsi_wwn to be null when wwn missing")
+	}
+}
+
+func TestClassifyVolumeDeleteErrorMapped(t *testing.T) {
+	err := msa.APIError{
+		Status: msa.Status{
+			Response: "The operation cannot complete because the volume is mapped to a host.",
+		},
+	}
+
+	guardrail, ok := classifyVolumeDeleteError("volume", "vol-data-01", err)
+	if !ok {
+		t.Fatalf("expected mapped guardrail")
+	}
+	if guardrail.summary != "Volume deletion blocked: mapped" {
+		t.Fatalf("unexpected summary: %s", guardrail.summary)
+	}
+	if !strings.Contains(guardrail.detail, "hpe_msa_volume_mapping") {
+		t.Fatalf("expected actionable mapping detail, got %s", guardrail.detail)
+	}
+	if !strings.Contains(guardrail.detail, "vol-data-01") {
+		t.Fatalf("expected target in detail, got %s", guardrail.detail)
+	}
+}
+
+func TestClassifyVolumeDeleteErrorInUse(t *testing.T) {
+	err := msa.APIError{
+		Status: msa.Status{
+			Response: "The operation cannot complete because the volume is in use by a snapshot.",
+		},
+	}
+
+	guardrail, ok := classifyVolumeDeleteError("clone", "clone-app-01", err)
+	if !ok {
+		t.Fatalf("expected in-use guardrail")
+	}
+	if guardrail.summary != "Clone deletion blocked: in use" {
+		t.Fatalf("unexpected summary: %s", guardrail.summary)
+	}
+	if !strings.Contains(guardrail.detail, "Delete dependent snapshots/clones") {
+		t.Fatalf("expected actionable dependency detail, got %s", guardrail.detail)
+	}
+	if !strings.Contains(guardrail.detail, "clone-app-01") {
+		t.Fatalf("expected target in detail, got %s", guardrail.detail)
+	}
+}
+
+func TestClassifyVolumeDeleteErrorNoMatch(t *testing.T) {
+	apiErr := msa.APIError{
+		Status: msa.Status{
+			Response: "No such volume exists.",
+		},
+	}
+	if _, ok := classifyVolumeDeleteError("volume", "vol-data-01", apiErr); ok {
+		t.Fatalf("did not expect guardrail for unrelated error")
+	}
+
+	plainErr := errors.New("network timeout")
+	if _, ok := classifyVolumeDeleteError("volume", "vol-data-01", plainErr); ok {
+		t.Fatalf("did not expect guardrail for non-API error")
 	}
 }

--- a/internal/provider/volume_delete_intelligence.go
+++ b/internal/provider/volume_delete_intelligence.go
@@ -1,0 +1,459 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/d3vi1/tf-provider-hpe-msa/internal/msa"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+)
+
+type volumeDeleteProbeClient interface {
+	Execute(ctx context.Context, parts ...string) (msa.Response, error)
+}
+
+func preDeleteVolumeUsageGuardrail(ctx context.Context, client volumeDeleteProbeClient, resourceKind string, hints ...string) (volumeDeleteGuardrail, bool) {
+	if client == nil {
+		return volumeDeleteGuardrail{}, false
+	}
+
+	identities := volumeIdentityHints(hints...)
+	if len(identities) == 0 {
+		return volumeDeleteGuardrail{}, false
+	}
+
+	resourceKind = strings.TrimSpace(resourceKind)
+	if resourceKind == "" {
+		resourceKind = "volume"
+	}
+	resourceLabel := titleCaseWord(resourceKind)
+	targetLabel := identities[0]
+
+	mappingCount, mappingCommand, mappingErr := probeVolumeMappings(ctx, client, identities)
+	if mappingErr != nil {
+		if errors.Is(mappingErr, context.Canceled) || errors.Is(mappingErr, context.DeadlineExceeded) {
+			return volumeDeleteGuardrail{
+				summary:   fmt.Sprintf("%s deletion interrupted", resourceLabel),
+				detail:    withDeleteClassification(true, fmt.Sprintf("Pre-delete mapping probe was interrupted before deletion could continue: %v", mappingErr)),
+				retryable: true,
+			}, true
+		}
+		tflog.Warn(ctx, "Volume pre-delete mapping probe failed; falling back to delete command", map[string]any{
+			"resource_kind": resourceKind,
+			"target":        targetLabel,
+			"error":         mappingErr.Error(),
+		})
+	}
+	if mappingCount > 0 {
+		return volumeDeleteGuardrail{
+			summary: fmt.Sprintf("%s deletion blocked: mapped", resourceLabel),
+			detail: withDeleteClassification(false, fmt.Sprintf(
+				"%s %q is still mapped (%d %s detected via `%s`). Remove related `hpe_msa_volume_mapping` resources (or unmap directly on the array), then run `terraform apply` again.",
+				resourceLabel,
+				targetLabel,
+				mappingCount,
+				pluralize(mappingCount, "mapping entry", "mapping entries"),
+				mappingCommand,
+			)),
+			retryable: false,
+		}, true
+	}
+
+	copyJob, copyCommand, copyErr := probeActiveVolumeCopyJob(ctx, client, identities)
+	if copyErr != nil {
+		if errors.Is(copyErr, context.Canceled) || errors.Is(copyErr, context.DeadlineExceeded) {
+			return volumeDeleteGuardrail{
+				summary:   fmt.Sprintf("%s deletion interrupted", resourceLabel),
+				detail:    withDeleteClassification(true, fmt.Sprintf("Pre-delete volume-copy probe was interrupted before deletion could continue: %v", copyErr)),
+				retryable: true,
+			}, true
+		}
+		tflog.Warn(ctx, "Volume pre-delete copy probe failed; falling back to delete command", map[string]any{
+			"resource_kind": resourceKind,
+			"target":        targetLabel,
+			"error":         copyErr.Error(),
+		})
+	}
+	if copyJob != nil {
+		jobContext := copyJobContext(copyJob)
+		return volumeDeleteGuardrail{
+			summary: fmt.Sprintf("%s deletion blocked: active copy", resourceLabel),
+			detail: withDeleteClassification(true, fmt.Sprintf(
+				"%s %q is participating in an active volume-copy job (%s, discovered via `%s`). Wait for the copy to finish, then run `terraform apply` again.",
+				resourceLabel,
+				targetLabel,
+				jobContext,
+				copyCommand,
+			)),
+			retryable: true,
+		}, true
+	}
+
+	connectionCount, connectionCommand, connectionErr := probeActiveVolumeConnections(ctx, client, identities)
+	if connectionErr != nil {
+		if errors.Is(connectionErr, context.Canceled) || errors.Is(connectionErr, context.DeadlineExceeded) {
+			return volumeDeleteGuardrail{
+				summary:   fmt.Sprintf("%s deletion interrupted", resourceLabel),
+				detail:    withDeleteClassification(true, fmt.Sprintf("Pre-delete connection/session probe was interrupted before deletion could continue: %v", connectionErr)),
+				retryable: true,
+			}, true
+		}
+		tflog.Warn(ctx, "Volume pre-delete connection/session probe failed; falling back to delete command", map[string]any{
+			"resource_kind": resourceKind,
+			"target":        targetLabel,
+			"error":         connectionErr.Error(),
+		})
+	}
+	if connectionCount > 0 {
+		return volumeDeleteGuardrail{
+			summary: fmt.Sprintf("%s deletion blocked: active sessions", resourceLabel),
+			detail: withDeleteClassification(true, fmt.Sprintf(
+				"%s %q still has active host/initiator connection %s (detected via `%s`). Disconnect active hosts or end sessions, then run `terraform apply` again.",
+				resourceLabel,
+				targetLabel,
+				pluralize(connectionCount, "entry", "entries"),
+				connectionCommand,
+			)),
+			retryable: true,
+		}, true
+	}
+
+	return volumeDeleteGuardrail{}, false
+}
+
+func probeVolumeMappings(ctx context.Context, client volumeDeleteProbeClient, identities []string) (int, string, error) {
+	commands := make([][]string, 0, len(identities)+1)
+	for _, identity := range identities {
+		commands = append(commands, []string{"show", "maps", "volume", identity})
+	}
+	commands = append(commands, []string{"show", "maps"})
+
+	var lastErr error
+	for _, parts := range commands {
+		response, err := client.Execute(ctx, parts...)
+		if err != nil {
+			if isSkippableUsageProbeError(err) {
+				continue
+			}
+			lastErr = err
+			continue
+		}
+
+		count := 0
+		for _, mapping := range msa.MappingsFromResponse(response) {
+			if volumeIdentityMatches(mapping.Volume, identities) || volumeIdentityMatches(mapping.VolumeSerial, identities) {
+				count++
+			}
+		}
+		if count > 0 {
+			return count, strings.Join(parts, " "), nil
+		}
+	}
+
+	return 0, "", lastErr
+}
+
+func probeActiveVolumeCopyJob(ctx context.Context, client volumeDeleteProbeClient, identities []string) (*msa.VolumeCopyJob, string, error) {
+	commands := [][]string{
+		{"show", "volume-copy"},
+		{"show", "volume-copies"},
+	}
+
+	var lastErr error
+	for _, parts := range commands {
+		response, err := client.Execute(ctx, parts...)
+		if err != nil {
+			if isSkippableUsageProbeError(err) {
+				continue
+			}
+			lastErr = err
+			continue
+		}
+
+		jobs := msa.VolumeCopyJobsFromResponse(response)
+		for i := range jobs {
+			job := jobs[i]
+			if !job.Active {
+				continue
+			}
+			if volumeIdentityMatches(job.Source, identities) || volumeIdentityMatches(job.Target, identities) {
+				candidate := job
+				return &candidate, strings.Join(parts, " "), nil
+			}
+		}
+	}
+
+	return nil, "", lastErr
+}
+
+func probeActiveVolumeConnections(ctx context.Context, client volumeDeleteProbeClient, identities []string) (int, string, error) {
+	commands := make([][]string, 0, len(identities)*2+3)
+	for _, identity := range identities {
+		commands = append(commands, []string{"show", "connections", "volume", identity})
+		commands = append(commands, []string{"show", "sessions", "volume", identity})
+	}
+	commands = append(commands,
+		[]string{"show", "connections"},
+		[]string{"show", "sessions"},
+		[]string{"show", "host-connections"},
+	)
+
+	var lastErr error
+	for _, parts := range commands {
+		response, err := client.Execute(ctx, parts...)
+		if err != nil {
+			if isSkippableUsageProbeError(err) {
+				continue
+			}
+			lastErr = err
+			continue
+		}
+
+		count := activeVolumeConnectionCount(response, identities)
+		if count > 0 {
+			return count, strings.Join(parts, " "), nil
+		}
+	}
+
+	return 0, "", lastErr
+}
+
+func activeVolumeConnectionCount(response msa.Response, identities []string) int {
+	count := 0
+	for _, obj := range response.ObjectsWithoutStatus() {
+		props := obj.PropertyMap()
+		if !isConnectionOrSessionObject(obj, props) {
+			continue
+		}
+		if !connectionObjectReferencesVolume(props, identities) {
+			continue
+		}
+		if !connectionObjectActive(props) {
+			continue
+		}
+		count++
+	}
+	return count
+}
+
+func isConnectionOrSessionObject(obj msa.Object, props map[string]string) bool {
+	shape := strings.ToLower(strings.TrimSpace(obj.BaseType + " " + obj.Name))
+	if containsAny(shape, "connection", "session") {
+		return true
+	}
+	return hasPropertyKeyContaining(props, "connection", "session")
+}
+
+func connectionObjectReferencesVolume(props map[string]string, identities []string) bool {
+	for key, value := range props {
+		lowerKey := strings.ToLower(strings.TrimSpace(key))
+		if lowerKey == "" {
+			continue
+		}
+		if containsAny(lowerKey, "volume", "serial", "durable", "wwn", "wwid") {
+			if volumeIdentityMatches(value, identities) {
+				return true
+			}
+			continue
+		}
+		if lowerKey == "name" && volumeIdentityMatches(value, identities) {
+			if hasPropertyKeyContaining(props, "volume", "serial", "durable", "lun") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func connectionObjectActive(props map[string]string) bool {
+	statusValues := make([]string, 0)
+	for key, value := range props {
+		lowerKey := strings.ToLower(strings.TrimSpace(key))
+		if !containsAny(lowerKey, "status", "state", "session", "connection", "login") {
+			continue
+		}
+		trimmed := strings.ToLower(strings.TrimSpace(value))
+		if trimmed == "" {
+			continue
+		}
+		statusValues = append(statusValues, trimmed)
+	}
+
+	if len(statusValues) == 0 {
+		return true
+	}
+	for _, status := range statusValues {
+		if containsAny(status, "disconnected", "logged out", "logout", "inactive", "offline", "closed", "down", "failed", "not connected", "no session") {
+			return false
+		}
+	}
+	return true
+}
+
+func hasPropertyKeyContaining(props map[string]string, candidates ...string) bool {
+	for key := range props {
+		lowerKey := strings.ToLower(strings.TrimSpace(key))
+		if containsAny(lowerKey, candidates...) {
+			return true
+		}
+	}
+	return false
+}
+
+func volumeIdentityHints(values ...string) []string {
+	seen := map[string]struct{}{}
+	identities := make([]string, 0, len(values))
+	for _, value := range values {
+		trimmed := strings.TrimSpace(value)
+		if trimmed == "" {
+			continue
+		}
+		key := strings.ToLower(trimmed)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		identities = append(identities, trimmed)
+	}
+	return identities
+}
+
+func volumeIdentityMatches(value string, identities []string) bool {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false
+	}
+
+	normalizedValue := strings.ToLower(value)
+	normalizedValueCompact := compactIdentity(normalizedValue)
+	tokens := splitIdentityTokens(normalizedValue)
+
+	for _, identity := range identities {
+		identity = strings.TrimSpace(identity)
+		if identity == "" {
+			continue
+		}
+		normalizedIdentity := strings.ToLower(identity)
+		if normalizedValue == normalizedIdentity {
+			return true
+		}
+
+		if compactIdentity(normalizedIdentity) != "" && normalizedValueCompact == compactIdentity(normalizedIdentity) {
+			return true
+		}
+
+		for _, token := range tokens {
+			if token == normalizedIdentity {
+				return true
+			}
+			if compactIdentity(token) != "" && compactIdentity(token) == compactIdentity(normalizedIdentity) {
+				return true
+			}
+		}
+
+		if len(normalizedIdentity) >= 8 && strings.Contains(normalizedValue, normalizedIdentity) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func splitIdentityTokens(value string) []string {
+	return strings.FieldsFunc(value, func(r rune) bool {
+		return !((r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '-' || r == '_' || r == '.')
+	})
+}
+
+func compactIdentity(value string) string {
+	replacer := strings.NewReplacer(":", "", "-", "", "_", "", ".", "", " ", "")
+	return replacer.Replace(strings.TrimSpace(value))
+}
+
+func isSkippableUsageProbeError(err error) bool {
+	return isUnsupportedUsageProbeError(err) || isNotFoundUsageProbeError(err)
+}
+
+func isUnsupportedUsageProbeError(err error) bool {
+	message, ok := volumeProbeAPIErrorMessage(err)
+	if !ok {
+		return false
+	}
+
+	return containsAny(message,
+		"invalid command",
+		"unknown command",
+		"unrecognized command",
+		"command not recognized",
+		"not supported",
+		"unsupported",
+		"not available",
+		"syntax error",
+		"invalid option",
+		"illegal parameter",
+		"invalid parameter",
+	)
+}
+
+func isNotFoundUsageProbeError(err error) bool {
+	message, ok := volumeProbeAPIErrorMessage(err)
+	if !ok {
+		return false
+	}
+
+	return containsAny(message,
+		"no such volume",
+		"volume does not exist",
+		"no object",
+		"not found",
+		"does not exist",
+	)
+}
+
+func volumeProbeAPIErrorMessage(err error) (string, bool) {
+	var apiErr msa.APIError
+	if !errors.As(err, &apiErr) {
+		return "", false
+	}
+
+	message := strings.ToLower(strings.TrimSpace(apiErr.Status.Response))
+	if message == "" {
+		return "", false
+	}
+
+	return message, true
+}
+
+func copyJobContext(job *msa.VolumeCopyJob) string {
+	if job == nil {
+		return "job details unavailable"
+	}
+
+	parts := make([]string, 0, 4)
+	if value := strings.TrimSpace(job.ID); value != "" {
+		parts = append(parts, "job id="+value)
+	}
+	if value := strings.TrimSpace(job.Source); value != "" {
+		parts = append(parts, "source="+value)
+	}
+	if value := strings.TrimSpace(job.Target); value != "" {
+		parts = append(parts, "target="+value)
+	}
+	if job.HasETA {
+		parts = append(parts, "eta="+job.ETA.String())
+	}
+
+	if len(parts) == 0 {
+		return "job details unavailable"
+	}
+	return strings.Join(parts, " ")
+}
+
+func pluralize(count int, singular, plural string) string {
+	if count == 1 {
+		return singular
+	}
+	return plural
+}

--- a/internal/provider/volume_delete_intelligence_test.go
+++ b/internal/provider/volume_delete_intelligence_test.go
@@ -1,0 +1,211 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/d3vi1/tf-provider-hpe-msa/internal/msa"
+)
+
+type fakeVolumeDeleteProbeClient struct {
+	results map[string]fakeVolumeDeleteProbeResult
+}
+
+type fakeVolumeDeleteProbeResult struct {
+	response msa.Response
+	err      error
+}
+
+func (f fakeVolumeDeleteProbeClient) Execute(_ context.Context, parts ...string) (msa.Response, error) {
+	key := strings.Join(parts, " ")
+	if result, ok := f.results[key]; ok {
+		return result.response, result.err
+	}
+
+	return msa.Response{}, msa.APIError{
+		Status: msa.Status{
+			Response: "Invalid command",
+		},
+	}
+}
+
+func TestPreDeleteVolumeUsageGuardrailMapped(t *testing.T) {
+	client := fakeVolumeDeleteProbeClient{
+		results: map[string]fakeVolumeDeleteProbeResult{
+			"show maps volume vol-data-01": {
+				response: msa.Response{
+					Objects: []msa.Object{
+						{
+							BaseType: "host-view-mappings",
+							Name:     "volume-view",
+							Properties: []msa.Property{
+								{Name: "volume", Value: "vol-data-01"},
+								{Name: "volume-serial", Value: "00c0ff3cab9c00000000000002010000"},
+								{Name: "access", Value: "read-write"},
+								{Name: "lun", Value: "12"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	guardrail, ok := preDeleteVolumeUsageGuardrail(context.Background(), client, "volume", "vol-data-01")
+	if !ok {
+		t.Fatalf("expected mapped guardrail")
+	}
+	if guardrail.summary != "Volume deletion blocked: mapped" {
+		t.Fatalf("unexpected summary: %s", guardrail.summary)
+	}
+	if guardrail.retryable {
+		t.Fatalf("expected mapped guardrail to be terminal")
+	}
+	if !strings.Contains(guardrail.detail, "Classification: terminal") {
+		t.Fatalf("expected terminal classification, got %s", guardrail.detail)
+	}
+	if !strings.Contains(guardrail.detail, "`show maps volume vol-data-01`") {
+		t.Fatalf("expected mapping command in detail, got %s", guardrail.detail)
+	}
+}
+
+func TestPreDeleteVolumeUsageGuardrailActiveCopy(t *testing.T) {
+	client := fakeVolumeDeleteProbeClient{
+		results: map[string]fakeVolumeDeleteProbeResult{
+			"show volume-copy": {
+				response: msa.Response{
+					Objects: []msa.Object{
+						{
+							BaseType: "volume-copy",
+							Name:     "volume-copy",
+							Properties: []msa.Property{
+								{Name: "copy-job-id", Value: "job-52"},
+								{Name: "source-volume-name", Value: "vol-data-01"},
+								{Name: "destination-volume-name", Value: "clone-01"},
+								{Name: "copy-status", Value: "In Progress"},
+								{Name: "estimated-time-remaining", Value: "120"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	guardrail, ok := preDeleteVolumeUsageGuardrail(context.Background(), client, "volume", "vol-data-01")
+	if !ok {
+		t.Fatalf("expected active copy guardrail")
+	}
+	if guardrail.summary != "Volume deletion blocked: active copy" {
+		t.Fatalf("unexpected summary: %s", guardrail.summary)
+	}
+	if !guardrail.retryable {
+		t.Fatalf("expected active copy guardrail to be retryable")
+	}
+	if !strings.Contains(guardrail.detail, "Classification: retryable") {
+		t.Fatalf("expected retryable classification, got %s", guardrail.detail)
+	}
+	if !strings.Contains(guardrail.detail, "job id=job-52") {
+		t.Fatalf("expected job id in detail, got %s", guardrail.detail)
+	}
+}
+
+func TestPreDeleteVolumeUsageGuardrailActiveConnection(t *testing.T) {
+	client := fakeVolumeDeleteProbeClient{
+		results: map[string]fakeVolumeDeleteProbeResult{
+			"show volume-copy": {
+				response: msa.Response{},
+			},
+			"show connections volume vol-data-01": {
+				response: msa.Response{
+					Objects: []msa.Object{
+						{
+							BaseType: "connection",
+							Name:     "connection",
+							Properties: []msa.Property{
+								{Name: "volume-name", Value: "vol-data-01"},
+								{Name: "connection-status", Value: "Connected"},
+								{Name: "host-name", Value: "app-host-01"},
+								{Name: "session-id", Value: "session-9"},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	guardrail, ok := preDeleteVolumeUsageGuardrail(context.Background(), client, "volume", "vol-data-01")
+	if !ok {
+		t.Fatalf("expected active session guardrail")
+	}
+	if guardrail.summary != "Volume deletion blocked: active sessions" {
+		t.Fatalf("unexpected summary: %s", guardrail.summary)
+	}
+	if !guardrail.retryable {
+		t.Fatalf("expected active sessions guardrail to be retryable")
+	}
+	if !strings.Contains(guardrail.detail, "Classification: retryable") {
+		t.Fatalf("expected retryable classification, got %s", guardrail.detail)
+	}
+}
+
+func TestPreDeleteVolumeUsageGuardrailFallbackOnProbeError(t *testing.T) {
+	client := fakeVolumeDeleteProbeClient{
+		results: map[string]fakeVolumeDeleteProbeResult{
+			"show maps volume vol-data-01": {
+				err: errors.New("dial tcp timeout"),
+			},
+		},
+	}
+
+	if guardrail, ok := preDeleteVolumeUsageGuardrail(context.Background(), client, "volume", "vol-data-01"); ok {
+		t.Fatalf("expected fallback without guardrail, got %s: %s", guardrail.summary, guardrail.detail)
+	}
+}
+
+func TestClassifyVolumeDeleteErrorActiveCopyRetryable(t *testing.T) {
+	err := msa.APIError{
+		Status: msa.Status{
+			Response: "Delete cannot proceed because an existing volume copy is in progress.",
+		},
+	}
+
+	guardrail, ok := classifyVolumeDeleteError("volume", "vol-data-01", err)
+	if !ok {
+		t.Fatalf("expected copy guardrail")
+	}
+	if guardrail.summary != "Volume deletion blocked: active copy" {
+		t.Fatalf("unexpected summary: %s", guardrail.summary)
+	}
+	if !guardrail.retryable {
+		t.Fatalf("expected retryable guardrail")
+	}
+	if !strings.Contains(guardrail.detail, "Classification: retryable") {
+		t.Fatalf("expected retryable classification, got %s", guardrail.detail)
+	}
+}
+
+func TestClassifyVolumeDeleteErrorActiveSessionsRetryable(t *testing.T) {
+	err := msa.APIError{
+		Status: msa.Status{
+			Response: "The volume has active sessions and cannot be deleted while hosts are connected.",
+		},
+	}
+
+	guardrail, ok := classifyVolumeDeleteError("clone", "clone-app-01", err)
+	if !ok {
+		t.Fatalf("expected session guardrail")
+	}
+	if guardrail.summary != "Clone deletion blocked: active sessions" {
+		t.Fatalf("unexpected summary: %s", guardrail.summary)
+	}
+	if !guardrail.retryable {
+		t.Fatalf("expected retryable guardrail")
+	}
+	if !strings.Contains(guardrail.detail, "Classification: retryable") {
+		t.Fatalf("expected retryable classification, got %s", guardrail.detail)
+	}
+}


### PR DESCRIPTION
## Summary
- detect clone conflict errors caused by an existing volume copy in progress
- query active volume-copy jobs via a new MSA client helper with robust ETA parsing/fallbacks
- retry clone copy using ETA+5s (max 3 retries) or fixed backoff (15s, 30s, 45s, 180s, 300s)
- include attempt count and best job context (job id/source/target/eta) on terminal failure
- add tests and XML fixtures for parser and retry planning behavior

## Testing
- go test ./...

Closes #52